### PR TITLE
Fixed calcTm so that  it doesn't raise an exception when using the breslauer method.   Also fixed a copy past error in the salt method settings.

### DIFF
--- a/primer3/bindings.py
+++ b/primer3/bindings.py
@@ -174,7 +174,7 @@ def calcTm(seq, mv_conc=50, dv_conc=0, dntp_conc=0.8, dna_conc=50,
     if tm_meth == None:
         raise ValueError('{} is not a valid tm calculation method'.format(
                          tm_meth))
-    salt_meth = _tm_methods.get(tm_method)
+    salt_meth = _salt_correction_methods.get(salt_corrections_method)
     if salt_meth == None:
         raise ValueError('{} is not a valid salt correction method'.format(
                          salt_meth))

--- a/primer3/wrappers.py
+++ b/primer3/wrappers.py
@@ -60,7 +60,7 @@ def calcTm(seq, mv_conc=50, dv_conc=0, dntp_conc=0.8, dna_conc=50,
     if tm_meth == None:
         raise ValueError('{} is not a valid tm calculation method'.format(
                          tm_meth))
-    salt_meth = _tm_methods.get(tm_method)
+    salt_meth = _salt_correction_methods.get(salt_corrections_method)
     if salt_meth == None:
         raise ValueError('{} is not a valid salt correction method'.format(
                          salt_meth))


### PR DESCRIPTION
Modified code to check for `value == None` instead of `not value` when verifying that the tm_methods dictionary returned a value.  This was a problem because that value could be 0.

Fixed a similar issue with salt method specification.
Also fixed a copy-paste error. 
