### PR TITLE
Use setup_requires cython pattern

### DIFF
--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -77,13 +77,13 @@ cdef unsigned char[:] _chars(s):
     return memoryview(s)
 
 cdef inline bytes _bytes(s):
-    IF IS_PY_THREE == 1:
+    if PY_MAJOR_VERSION > 2:
         if isinstance(s, str):
             # encode to the specific encoding used inside of the module
             return (<str>s).encode('utf8')
         else:
             return s
-    ELSE:
+    else:
         return s
 
 # ~~~~~~~~~ Load base thermodynamic parameters into memory from file ~~~~~~~~ #

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,6 @@ from distutils import log as setup_log
 from os.path import join as pjoin
 from os.path import relpath as rpath
 
-from Cython.Build import cythonize
-
 
 with open('README.rst') as fd:
     LONG_DESCRIPTION = fd.read()
@@ -186,13 +184,6 @@ if ('build_ext' in sys.argv or 'install' in sys.argv):
         p3Build()
         P3_BUILT = True
 
-is_py_3 = int(sys.version_info[0] > 2)
-thermoanalysis_ext_list = cythonize(
-    [thermoanalysis_ext],
-    compile_time_env={'IS_PY_THREE': is_py_3},
-    force=True
-)
-
 # Insure that we don't include the built Cython module in the dist
 if 'sdist' in sys.argv:
     os.remove(os.path.join(MODULE_PATH, 'thermoanalysis.c'))
@@ -221,11 +212,11 @@ setup(
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)'
     ],
     packages=['primer3'],
-    ext_modules=[primerdesign_ext] + thermoanalysis_ext_list,
+    ext_modules=[primerdesign_ext, thermoanalysis_ext],
     package_data={'primer3': p3_files},
     cmdclass={'install_lib': CustomInstallLib, 'sdist': CustomSdist,
-              'build_ext': CustomBuildExt},
+              'build_clib': CustomBuildClib},
     test_suite='tests',
-    install_requires=['Cython'],
+    setup_requires=['Cython', 'setuptools>=18.0'],
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,10 @@ import sys
 
 try:
     from setuptools import setup, Extension
-    from setuptools.command import install_lib, sdist, build_ext
+    from setuptools.command import install_lib, sdist, build_clib
 except ImportError:
     from distutils.core import setup, Extension
-    from distutils.command import install_lib, sdist, build_ext
+    from distutils.command import install_lib, sdist, build_clib
 
 from distutils import log as setup_log
 
@@ -144,7 +144,7 @@ class CustomSdist(sdist.sdist):
         sdist.sdist.run(self)
 
 
-class CustomBuildExt(build_ext.build_ext):
+class CustomBuildClib(build_clib.build_clib):
 
     def run(self):
         global P3_BUILT
@@ -153,7 +153,7 @@ class CustomBuildExt(build_ext.build_ext):
             p3Clean()
             p3Build()
             P3_BUILT = True
-        build_ext.build_ext.run(self)
+        build_clib.build_clib.run(self)
 
 
 # Build the C API and Cython extensions


### PR DESCRIPTION
Setuptools [supports](https://github.com/pypa/setuptools/blob/master/CHANGES.rst#180) building .pyx files as extensions. This PR takes advantage of that mechanism and avoids importing cython in setup.py. This allows primer3-py to be installed into an environment where cython was not previously installed.

This is helpful for me because I have a package A, which depends on a package B, which depends on primer3-py. When I am testing package A, I want tox to install package B from git; there's no opportunity to install cython into the tox environment before it tries to install package B (or its dependency primer3-py).

Oddly, this requires avoiding build_ext. Setuptools checks to see whether it can import cython when the build_ext command is imported. Setuptools intentionally delays the build_ext import until after setup_requires dependencies are installed. Importing build_ext in setup.py breaks that, because that means that build_ext gets imported before setup() is called, so the delay strategy fails. Happily, we can avoid breaking the delayed import strategy by building the library with build_clib instead of build_ext, which maybe feels a little more apropos anyway.

This PR also declares that cython is not a runtime dependency of primer3-py.