### PR TITLE
Support generation of ASCII structure strings

### DIFF
--- a/primer3/bindings.py
+++ b/primer3/bindings.py
@@ -68,7 +68,7 @@ def _setThermoArgs(mv_conc=50, dv_conc=0, dntp_conc=0.8, dna_conc=50,
 
 
 def calcHairpin(seq, mv_conc=50.0, dv_conc=0.0, dntp_conc=0.8, dna_conc=50.0,
-                temp_c=37, max_loop=30):
+                temp_c=37, max_loop=30, output_structure=False):
     ''' Calculate the hairpin formation thermodynamics of a DNA sequence.
 
     **Note that the maximum length of `seq` is 60 bp.** This is a cap suggested
@@ -84,6 +84,7 @@ def calcHairpin(seq, mv_conc=50.0, dv_conc=0.0, dntp_conc=0.8, dna_conc=50.0,
         dna_conc (float/int, optional): DNA conc. (nM)
         temp_c (int, optional): Simulation temperature for dG (Celsius)
         max_loop(int, optional): Maximum size of loops in the structure
+        output_structure (bool) : If `True`, the ASCII dimer structure is saved
 
     Returns:
         A `ThermoResult` object with thermodynamic characteristics of the
@@ -94,11 +95,11 @@ def calcHairpin(seq, mv_conc=50.0, dv_conc=0.0, dntp_conc=0.8, dna_conc=50.0,
 
     '''
     _setThermoArgs(**locals())
-    return _THERMO_ANALYSIS.calcHairpin(seq).checkExc()
+    return _THERMO_ANALYSIS.calcHairpin(seq, output_structure).checkExc()
 
 
 def calcHomodimer(seq, mv_conc=50, dv_conc=0, dntp_conc=0.8, dna_conc=50,
-                  temp_c=37, max_loop=30):
+                  temp_c=37, max_loop=30, output_structure=False):
     ''' Calculate the homodimerization thermodynamics of a DNA sequence.
 
     **Note that the maximum length of ``seq`` is 60 bp.** This is a cap imposed
@@ -117,6 +118,7 @@ def calcHomodimer(seq, mv_conc=50, dv_conc=0, dntp_conc=0.8, dna_conc=50,
         temp_c (int, optional)          : Simulation temperature for dG (C)
         max_loop (int, optional)        : Maximum size of loops in the
                                           structure
+        output_structure (bool) : If `True`, the ASCII dimer structure is saved
 
     Returns:
         A `ThermoResult` object with thermodynamic characteristics of the
@@ -127,11 +129,12 @@ def calcHomodimer(seq, mv_conc=50, dv_conc=0, dntp_conc=0.8, dna_conc=50,
 
     '''
     _setThermoArgs(**locals())
-    return _THERMO_ANALYSIS.calcHomodimer(seq).checkExc()
+    return _THERMO_ANALYSIS.calcHomodimer(seq, output_structure).checkExc()
 
 
 def calcHeterodimer(seq1, seq2, mv_conc=50, dv_conc=0, dntp_conc=0.8,
-                    dna_conc=50, temp_c=37, max_loop=30):
+                    dna_conc=50, temp_c=37, max_loop=30,
+                    output_structure=False):
     ''' Calculate the heterodimerization thermodynamics of two DNA sequences.
 
     **Note that at least one of the two sequences must by <60 bp in length.**
@@ -151,6 +154,7 @@ def calcHeterodimer(seq1, seq2, mv_conc=50, dv_conc=0, dntp_conc=0.8,
         dna_conc (float/int)    : DNA conc. (nM)
         temp_c (int)            : Simulation temperature for dG (Celsius)
         max_loop(int)           : Maximum size of loops in the structure
+        output_structure (bool) : If `True`, the ASCII dimer structure is saved
 
     Returns:
         A `ThermoResult` object with thermodynamic characteristics of the
@@ -161,7 +165,7 @@ def calcHeterodimer(seq1, seq2, mv_conc=50, dv_conc=0, dntp_conc=0.8,
 
     '''
     _setThermoArgs(**locals())
-    return _THERMO_ANALYSIS.calcHeterodimer(seq1, seq2).checkExc()
+    return _THERMO_ANALYSIS.calcHeterodimer(seq1, seq2, output_structure).checkExc()
 
 
 def calcEndStability(seq1, seq2, mv_conc=50, dv_conc=0, dntp_conc=0.8,

--- a/primer3/src/libprimer3/libprimer3.c
+++ b/primer3/src/libprimer3/libprimer3.c
@@ -4694,7 +4694,7 @@ align_thermod(const char *s1,
 {
   int thal_trace=0;
   thal_results r;
-  thal((const unsigned char *) s1, (const unsigned char *) s2, a, &r, 1);
+  thal((const unsigned char *) s1, (const unsigned char *) s2, a, &r, 1, NULL);
   if (thal_trace) {
     fprintf(stdout,
        "thal, thal_args, type=%d maxLoop=%d mv=%f dv=%f "

--- a/primer3/src/libprimer3/thal.c
+++ b/primer3/src/libprimer3/thal.c
@@ -2934,6 +2934,9 @@ drawHairpin(int* bp, double mh, double ms, int temponly, double temp, thal_resul
     if(temponly == 0) {
       mg = mh - (temp * (ms + (((N/2)-1) * saltCorrection)));
       ms = ms + (((N/2)-1) * saltCorrection);
+      o->ds = (double) ms;
+      o->dh = (double) mh;
+      o->dg = (double) mg;
       o->temp = (double) t;
       if (output_buf == NULL) {
         printf("Calculated thermodynamical parameters for dimer:\t%d\tdS = %g\tdH = %g\tdG = %g\tt = %g\n",
@@ -3008,6 +3011,9 @@ drawDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, dou
       G = (H) - (t37 * (S + (N * saltCorrection)));
       S = S + (N * saltCorrection);
       o->temp = (double) t;
+      o->ds = (double) S;
+      o->dh = (double) H;
+      o->dg = (double) G;
       /* maybe user does not need as precise as that */
       /* printf("Thermodynamical values:\t%d\tdS = %g\tdH = %g\tdG = %g\tt = %g\tN = %d, SaltC=%f, RC=%f\n",
         len1, (double) S, (double) H, (double) G, (double) t, (int) N, saltCorrection, RC); */

--- a/primer3/src/libprimer3/thal.c
+++ b/primer3/src/libprimer3/thal.c
@@ -255,10 +255,10 @@ static void calcDimer(int*, int*, double, double, double, int, double, thal_resu
 static void calcHairpin(int*, double, double, int, double, thal_results *);
 
 /* prints ascii output of dimer structure */
-static void drawDimer(int*, int*, double, double, double, int, double, thal_results *);
+static void drawDimer(int*, int*, double, double, double, int, double, thal_results *, char *);
 
 /* prints ascii output of hairpin structure */
-static void drawHairpin(int*, double, double, int, double, thal_results *);
+static void drawHairpin(int*, double, double, int, double, thal_results *, char *);
 
 static int equal(double a, double b);
 
@@ -399,7 +399,8 @@ thal(const unsigned char *oligo_f,
      const unsigned char *oligo_r,
      const thal_args *a,
      thal_results *o,
-     const int print_output)
+     const int print_output,
+     char *ascii_structure)
 {
   double* SH;
   int i, j;
@@ -550,7 +551,7 @@ thal(const unsigned char *oligo_f,
       tracebacku(bp, a->maxLoop, o);
       /* traceback for unimolecular structure */
       if (print_output) {
-        drawHairpin(bp, mh, ms, a->temponly,a->temp, o);
+        drawHairpin(bp, mh, ms, a->temponly,a->temp, o, ascii_structure);
       } else {
         calcHairpin(bp, mh, ms, a->temponly,a->temp, o);
       }
@@ -644,7 +645,8 @@ thal(const unsigned char *oligo_f,
     if (isFinite(EnthalpyDPT(bestI, bestJ))) {
       traceback(bestI, bestJ, RC, ps1, ps2, a->maxLoop, o);
       if (print_output) {
-        drawDimer(ps1, ps2, SHleft, dH, dS, a->temponly, a->temp, o);
+        drawDimer(ps1, ps2, SHleft, dH, dS, a->temponly, a->temp, o,
+                  ascii_structure);
       } else {
         calcDimer(ps1, ps2, SHleft, dH, dS, a->temponly, a->temp, o);
       }
@@ -2903,14 +2905,14 @@ calcDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, dou
 }
 
 static void
-drawHairpin(int* bp, double mh, double ms, int temponly, double temp, thal_results *o)
+drawHairpin(int* bp, double mh, double ms, int temponly, double temp, thal_results *o, char *output_buf)
 {
   /* Plain text */
   int i, N = 0;
   double mg, t;
   char* asciiRow;
   if (!isFinite(ms) || !isFinite(mh)) {
-    if(temponly == 0) {
+    if (temponly == 0 && output_buf == NULL) {
       printf("0\tdS = %g\tdH = %g\tinf\tinf\n", (double) ms,(double) mh);
 #ifdef DEBUG
       fputs("No temperature could be calculated\n",stderr);
@@ -2933,8 +2935,10 @@ drawHairpin(int* bp, double mh, double ms, int temponly, double temp, thal_resul
       mg = mh - (temp * (ms + (((N/2)-1) * saltCorrection)));
       ms = ms + (((N/2)-1) * saltCorrection);
       o->temp = (double) t;
-      printf("Calculated thermodynamical parameters for dimer:\t%d\tdS = %g\tdH = %g\tdG = %g\tt = %g\n",
-        len1, (double) ms, (double) mh, (double) mg, (double) t);
+      if (output_buf == NULL) {
+        printf("Calculated thermodynamical parameters for dimer:\t%d\tdS = %g\tdH = %g\tdG = %g\tt = %g\n",
+          len1, (double) ms, (double) mh, (double) mg, (double) t);
+      }
     } else {
       o->temp = (double) t;
       return;
@@ -2954,22 +2958,38 @@ drawHairpin(int* bp, double mh, double ms, int temponly, double temp, thal_resul
       }
     }
   }
-  printf("SEQ\t");
-  for(i = 0; i < len1; ++i) printf("%c",asciiRow[i]);
-  printf("\nSTR\t%s\n", oligo1);
+  if (output_buf != NULL) {
+    sprintf(output_buf, "SEQ\t");
+    output_buf += 4;
+  } else{
+    printf("SEQ\t");
+  }
+  for(i = 0; i < len1; ++i) {
+    if (output_buf != NULL) {
+      sprintf(output_buf, "%c", asciiRow[i]);
+      output_buf++;
+    } else {
+      printf("%c",asciiRow[i]);
+    }
+  }
+  if (output_buf != NULL) {
+    sprintf(output_buf, "\nSTR\t%s\n", oligo1);
+  } else {
+    printf("\nSTR\t%s\n", oligo1);
+  }
   free(asciiRow);
   return;
 }
 
 static void
-drawDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, double t37, thal_results *o)
+drawDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, double t37, thal_results *o, char *output_buf)
 {
   int i, j, k, numSS1, numSS2, N;
   char* duplex[4];
   double G, t;
   t = G = 0;
   if (!isFinite(temp)) {
-    if (temponly == 0) {
+    if (temponly == 0 && output_buf == NULL) {
       printf("No predicted secondary structures for given sequences\n");
     }
     o->temp = 0.0; /* lets use generalization here; this should rather be very negative value */
@@ -2991,8 +3011,10 @@ drawDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, dou
       /* maybe user does not need as precise as that */
       /* printf("Thermodynamical values:\t%d\tdS = %g\tdH = %g\tdG = %g\tt = %g\tN = %d, SaltC=%f, RC=%f\n",
         len1, (double) S, (double) H, (double) G, (double) t, (int) N, saltCorrection, RC); */
-      printf("Calculated thermodynamical parameters for dimer:\tdS = %g\tdH = %g\tdG = %g\tt = %g\n",
-        (double) S, (double) H, (double) G, (double) t);
+      if (output_buf == NULL) {
+        printf("Calculated thermodynamical parameters for dimer:\tdS = %g\tdH = %g\tdG = %g\tt = %g\n",
+          (double) S, (double) H, (double) G, (double) t);
+      }
     } else {
       o->temp = (double) t;
       return;
@@ -3071,14 +3093,25 @@ drawDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, dou
       }
     }
   }
-  printf("SEQ\t");
-  printf("%s\n", duplex[0]);
-  printf("SEQ\t");
-  printf("%s\n", duplex[1]);
-  printf("STR\t");
-  printf("%s\n", duplex[2]);
-  printf("STR\t");
-  printf("%s\n", duplex[3]);
+  if (output_buf == NULL) {
+    printf("SEQ\t");
+    printf("%s\n", duplex[0]);
+    printf("SEQ\t");
+    printf("%s\n", duplex[1]);
+    printf("STR\t");
+    printf("%s\n", duplex[2]);
+    printf("STR\t");
+    printf("%s\n", duplex[3]);
+  } else {
+    sprintf(
+      output_buf,
+      "SEQ\t%s\nSEQ\t%s\nSTR\t%s\nSTR\t%s\n",
+      duplex[0],
+      duplex[1],
+      duplex[2],
+      duplex[3]
+    );
+  }
 
   free(duplex[0]);
   free(duplex[1]);

--- a/primer3/src/libprimer3/thal.h
+++ b/primer3/src/libprimer3/thal.h
@@ -151,6 +151,7 @@ void thal(const unsigned char *oligo1,
 	  const unsigned char *oligo2,
 	  const thal_args* a,
 	  thal_results* o,
-      const int print_output);
+    const int print_output,
+    char *ascii_structure);
 
 #endif

--- a/primer3/src/libprimer3/thal_main.c
+++ b/primer3/src/libprimer3/thal_main.c
@@ -320,11 +320,11 @@ if(a.debug == 0) {
 
    /* execute thermodynamical alignemnt */
    if(a.dimer==0 && oligo1!=NULL){
-      thal(oligo1,oligo1,&a,&o,1);
+      thal(oligo1,oligo1,&a,&o,1,NULL);
    } else if(a.dimer==0 && oligo1==NULL && oligo2!=NULL) {
-      thal(oligo2,oligo2,&a,&o,1);
+      thal(oligo2,oligo2,&a,&o,1,NULL);
    } else {
-      thal(oligo1,oligo2,&a,&o,1);
+      thal(oligo1,oligo2,&a,&o,1,NULL);
    }
    /* encountered error during thermodynamical calc */
    if (o.temp == THAL_ERROR_SCORE) {

--- a/primer3/thermoanalysis.pxd
+++ b/primer3/thermoanalysis.pxd
@@ -18,7 +18,7 @@
 thermoanalysis.pxd
 ~~~~~~~~~~~~~~~~~~
 
-Cython header file for thermoanalysis.pyx -- allows for cross-project Cython / 
+Cython header file for thermoanalysis.pyx -- allows for cross-project Cython /
 C integration of the low-level thermodynamic analysis bindings.
 
 '''
@@ -41,7 +41,7 @@ cdef extern from "thal.h":
         double temp               # temp at which hairpins will be calculated
         int temponly              # print only temp to stderr
         int dimer                 # if non-zero dimer structure is calculated
-    
+
     ctypedef struct thal_results:
         char msg[255]
         int no_structure # Added no structure (1 if no structure found)
@@ -58,7 +58,8 @@ cdef extern from "thal.h":
                 const unsigned char*,
                 const thal_args*,
                 thal_results*,
-                const int)
+                const int,
+                char*)
 
     int get_thermodynamic_values(const char*, thal_results *)
 
@@ -67,6 +68,8 @@ cdef extern from "thal.h":
 
 cdef class ThermoResult:
     cdef thal_results thalres
+    cdef public object ascii_structure
+
 
 cdef class ThermoAnalysis:
     cdef thal_args thalargs
@@ -74,13 +77,24 @@ cdef class ThermoAnalysis:
     cdef public int _tm_method
     cdef public int _salt_correction_method
 
-    cdef inline ThermoResult calcHeterodimer_c(ThermoAnalysis self,
-                                               unsigned char*s1,
-                                               unsigned char* s2)
+    cdef inline ThermoResult calcHeterodimer_c(
+        ThermoAnalysis self,
+        unsigned char*s1,
+        unsigned char* s2,
+        bint output_structure
+    )
 
-    cdef inline ThermoResult calcHomodimer_c(ThermoAnalysis self, unsigned char*s1)
+    cdef inline ThermoResult calcHomodimer_c(
+        ThermoAnalysis self,
+        unsigned char*s1,
+        bint output_structure
+    )
 
-    cdef inline ThermoResult calcHairpin_c(ThermoAnalysis self, unsigned char*s1)
+    cdef inline ThermoResult calcHairpin_c(
+        ThermoAnalysis self,
+        unsigned char*s1,
+        bint output_structure
+    )
 
     cdef inline ThermoResult calcEndStability_c(ThermoAnalysis self,
                                                 unsigned char*s1,
@@ -88,10 +102,10 @@ cdef class ThermoAnalysis:
 
     cdef inline double calcTm_c(ThermoAnalysis self, char* s1)
 
-    cpdef calcHeterodimer(ThermoAnalysis self, seq1, seq2)
+    cpdef calcHeterodimer(ThermoAnalysis self, seq1, seq2, output_structure=*)
 
-    cpdef calcHomodimer(ThermoAnalysis self, seq1)
+    cpdef calcHomodimer(ThermoAnalysis self, seq1, output_structure=*)
 
-    cpdef calcHairpin(ThermoAnalysis self, seq1)
+    cpdef calcHairpin(ThermoAnalysis self, seq1, output_structure=*)
 
     cpdef misprimingCheck(ThermoAnalysis self, putative_seq, sequences,  double tm_threshold)

--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -156,6 +156,21 @@ cdef class ThermoResult:
         def __get__(self):
             return self.thalres.dg
 
+    property ascii_structure_lines:
+        ''' ASCII structure representation split into indivudial lines
+
+        e.g.,
+            [u'SEQ\t         -    T CCT-   A   TTGCTTTGAAACAATTCACCATGCAGA',
+             u'SEQ\t      TGC GATG G    GCT TGC                           ',
+             u'STR\t      ACG CTAC C    CGA ACG                           ',
+             u'STR\tAACCTT   T    T TTAT   G   TAGGCGAGCCACCAGCGGCATAGTAA-']
+        '''
+        def __get__(self):
+            if self.ascii_structure:
+                return self.ascii_structure.strip('\n').split('\n')
+            else:
+                return None
+
     def checkExc(self):
         ''' Check the ``.msg`` attribute of the internal thalres struct and
         raise a ``RuntimeError`` exception if it is not an empty string.

--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -40,6 +40,9 @@ Calculations are performed under the following paradigm:
 
 '''
 
+from libc.stdlib cimport malloc, free
+from libc.string cimport strlen
+
 from cpython.version cimport PY_MAJOR_VERSION
 import atexit
 
@@ -183,6 +186,7 @@ cdef class ThermoResult:
         '''
         return {
             'structure_found': self.structure_found,
+            'ascii_structure': self.ascii_structure,
             'tm': precision(self.tm, pts),
             'dg': precision(self.dg, pts),
             'dh': precision(self.dh, pts),
@@ -329,16 +333,38 @@ cdef class ThermoAnalysis:
 
     cdef inline ThermoResult calcHeterodimer_c(ThermoAnalysis self,
                                                unsigned char *s1,
-                                               unsigned char *s2):
+                                               unsigned char *s2,
+                                               bint output_structure):
         cdef ThermoResult tr_obj = ThermoResult()
+        cdef char* c_ascii_structure = NULL
 
         self.thalargs.dimer = 1
         self.thalargs.type = <thal_alignment_type> 1
-        thal(<const unsigned char*> s1, <const unsigned char*> s2,
-         <const thal_args *> &(self.thalargs), &(tr_obj.thalres), 0)
+        if (output_structure == 1):
+            c_ascii_structure = <char *>malloc(
+                (strlen(<const char*>s1) + strlen(<const char*>s2)) * 4 + 24)
+            c_ascii_structure[0] = '\0';
+        thal(
+            <const unsigned char*> s1,
+            <const unsigned char*> s2,
+            <const thal_args *> &(self.thalargs),
+            &(tr_obj.thalres),
+            1 if c_ascii_structure else 0,
+            c_ascii_structure
+        )
+        if (output_structure == 1):
+            try:
+                tr_obj.ascii_structure = c_ascii_structure.decode('UTF-8')
+            finally:
+                free(c_ascii_structure)
         return tr_obj
 
-    cpdef calcHeterodimer(ThermoAnalysis self, seq1, seq2):
+    cpdef calcHeterodimer(
+            ThermoAnalysis self,
+            seq1,
+            seq2,
+            output_structure=False
+        ):
         ''' Calculate the heterodimer formation thermodynamics of two DNA
         sequences, ``seq1`` and ``seq2``
         '''
@@ -349,7 +375,8 @@ cdef class ThermoAnalysis:
         cdef unsigned char* s1 = py_s1
         py_s2 = <bytes> _bytes(seq2)
         cdef unsigned char* s2 = py_s2
-        return ThermoAnalysis.calcHeterodimer_c(<ThermoAnalysis> self, s1, s2)
+        return ThermoAnalysis.calcHeterodimer_c(<ThermoAnalysis> self, s1, s2,
+                                                output_structure)
 
     cpdef misprimingCheck(ThermoAnalysis self, putative_seq, sequences,
                                 double tm_threshold):
@@ -383,7 +410,7 @@ cdef class ThermoAnalysis:
         for i, seq in enumerate(sequences):
             py_s2 = <bytes> _bytes(seq)
             s2 = py_s2
-            offtarget_tm = ThermoAnalysis.calcHeterodimer_c(<ThermoAnalysis> self, s1, s2).tm
+            offtarget_tm = ThermoAnalysis.calcHeterodimer_c(<ThermoAnalysis> self, s1, s2, 0).tm
             if offtarget_tm > max_offtarget_tm:
                 max_offtarget_seq_idx = i
                 max_offtarget_tm = offtarget_tm
@@ -393,16 +420,34 @@ cdef class ThermoAnalysis:
         return is_offtarget, max_offtarget_seq_idx, max_offtarget_tm
 
     cdef inline ThermoResult calcHomodimer_c(ThermoAnalysis self,
-                                             unsigned char *s1):
+                                             unsigned char *s1,
+                                             bint output_structure):
         cdef ThermoResult tr_obj = ThermoResult()
+        cdef char* c_ascii_structure = NULL
 
         self.thalargs.dimer = 1
         self.thalargs.type = <thal_alignment_type> 1
-        thal(<const unsigned char*> s1, <const unsigned char*> s1,
-         <const thal_args *> &(self.thalargs), &(tr_obj.thalres), 0)
+        if (output_structure == 1):
+            c_ascii_structure = <char *>malloc(
+                (strlen(<const char*>s1) * 8 + 24)
+            )
+            c_ascii_structure[0] = '\0';
+        thal(
+            <const unsigned char*> s1,
+            <const unsigned char*> s1,
+            <const thal_args *> &(self.thalargs),
+            &(tr_obj.thalres),
+            1 if c_ascii_structure else 0,
+            c_ascii_structure
+        )
+        if (output_structure == 1):
+            try:
+                tr_obj.ascii_structure = c_ascii_structure.decode('UTF-8')
+            finally:
+                free(c_ascii_structure)
         return tr_obj
 
-    cpdef calcHomodimer(ThermoAnalysis self, seq1):
+    cpdef calcHomodimer(ThermoAnalysis self, seq1, output_structure=False):
         ''' Calculate the homodimer formation thermodynamics of a DNA
         sequence, ``seq1``
         '''
@@ -410,19 +455,38 @@ cdef class ThermoAnalysis:
         # cooerce to a unsigned char *
         py_s1 = <bytes> _bytes(seq1)
         cdef unsigned char* s1 = py_s1
-        return ThermoAnalysis.calcHomodimer_c(<ThermoAnalysis> self, s1)
+        return ThermoAnalysis.calcHomodimer_c(<ThermoAnalysis> self, s1,
+                                              output_structure)
 
     cdef inline ThermoResult calcHairpin_c(ThermoAnalysis self,
-                                           unsigned char *s1):
+                                           unsigned char *s1,
+                                           bint output_structure):
         cdef ThermoResult tr_obj = ThermoResult()
+        cdef char* c_ascii_structure = NULL
 
         self.thalargs.dimer = 0
         self.thalargs.type = <thal_alignment_type> 4
-        thal(<const unsigned char*> s1, <const unsigned char*> s1,
-         <const thal_args *> &(self.thalargs), &(tr_obj.thalres), 0)
+        if (output_structure == 1):
+            c_ascii_structure = <char *>malloc(
+                (strlen(<const char*>s1) * 2 + 24)
+            )
+            c_ascii_structure[0] = '\0';
+        thal(
+            <const unsigned char*> s1,
+            <const unsigned char*> s1,
+            <const thal_args *> &(self.thalargs),
+            &(tr_obj.thalres),
+            1 if c_ascii_structure else 0,
+            c_ascii_structure
+        )
+        if (output_structure == 1):
+            try:
+                tr_obj.ascii_structure = c_ascii_structure.decode('UTF-8')
+            finally:
+                free(c_ascii_structure)
         return tr_obj
 
-    cpdef calcHairpin(ThermoAnalysis self, seq1):
+    cpdef calcHairpin(ThermoAnalysis self, seq1, output_structure=False):
         ''' Calculate the hairpin formation thermodynamics of a DNA
         sequence, ``seq1``
         '''
@@ -430,7 +494,8 @@ cdef class ThermoAnalysis:
         # cooerce to a unsigned char *
         py_s1 = <bytes> _bytes(seq1)
         cdef unsigned char* s1 = py_s1
-        return ThermoAnalysis.calcHairpin_c(<ThermoAnalysis> self, s1)
+        return ThermoAnalysis.calcHairpin_c(<ThermoAnalysis> self, s1,
+                                            output_structure)
 
     cdef inline ThermoResult calcEndStability_c(ThermoAnalysis self,
                                                unsigned char *s1,
@@ -440,7 +505,7 @@ cdef class ThermoAnalysis:
         self.thalargs.dimer = 1
         self.thalargs.type = <thal_alignment_type> 2
         thal(<const unsigned char*> s1, <const unsigned char*> s2,
-         <const thal_args *> &(self.thalargs), &(tr_obj.thalres), 0)
+         <const thal_args *> &(self.thalargs), &(tr_obj.thalres), 0, NULL)
         return tr_obj
 
     def calcEndStability(ThermoAnalysis self, seq1, seq2):

--- a/primer3/wrappers.py
+++ b/primer3/wrappers.py
@@ -98,25 +98,35 @@ _ntthal_re = re.compile(b'dS\s+=\s+(\S+)\s+dH\s+=\s+(\S+)\s+' +
                         b'dG\s+=\s+(\S+)\s+t\s+=\s+(\S+)')
 
 THERMORESULT = namedtuple('thermoresult', [
-    'result',           # True if a structure is present
-    'ds',               # Entropy (cal/(K*mol))
-    'dh',               # Enthalpy (kcal/mol)
-    'dg',               # Gibbs free energy
-    'tm']               # Melting temperature (deg. Celsius)
+        'result',           # True if a structure is present
+        'ds',               # Entropy (cal/(K*mol))
+        'dh',               # Enthalpy (kcal/mol)
+        'dg',               # Gibbs free energy
+        'tm',               # Melting temperature (deg. Celsius)
+        'ascii_structure'   # ASCII representation of structure
+    ]
 )
 
-NULLTHERMORESULT = THERMORESULT(False, 0, 0, 0, 0)
+NULLTHERMORESULT = THERMORESULT(False, 0, 0, 0, 0, '')
 
 def _parse_ntthal(ntthal_output):
     ''' Helper method that uses regex to parse ntthal output. '''
     parsed_vals = re.search(_ntthal_re, ntthal_output)
-    return THERMORESULT(
-        True,                           # Structure found
-        float(parsed_vals.group(1)),    # dS
-        float(parsed_vals.group(2)),    # dH
-        float(parsed_vals.group(3)),    # dG
-        float(parsed_vals.group(4))     # tm
-    ) if parsed_vals else NULLTHERMORESULT
+    if parsed_vals:
+        ascii_structure = (
+            ntthal_output[ntthal_output.index(b'\n') + 1:].decode('utf-8')
+        )
+        res = THERMORESULT(
+            True,                           # Structure found
+            float(parsed_vals.group(1)),    # dS
+            float(parsed_vals.group(2)),    # dH
+            float(parsed_vals.group(3)),    # dG
+            float(parsed_vals.group(4)),    # tm
+            ascii_structure
+        )
+    else:
+        res = NULLTHERMORESULT
+    return res
 
 
 def calcThermo(seq1, seq2, calc_type='ANY', mv_conc=50, dv_conc=0,

--- a/tests/test_thermoanalysis.py
+++ b/tests/test_thermoanalysis.py
@@ -90,7 +90,8 @@ class TestLowLevelBindings(unittest.TestCase):
                 dntp_conc=self.dntp_conc,
                 dna_conc=self.dna_conc,
                 temp_c=self.temp_c,
-                max_loop=self.max_loop
+                max_loop=self.max_loop,
+                output_structure=True
             )
             wrapper_res = wrappers.calcHairpin(
                 seq=self.seq1,
@@ -102,6 +103,10 @@ class TestLowLevelBindings(unittest.TestCase):
                 max_loop=self.max_loop
             )
             self.assertEqual(int(binding_res.tm), int(wrapper_res.tm))
+            self.assertEqual(
+                binding_res.ascii_structure,
+                wrapper_res.ascii_structure
+            )
 
     def test_calcHomodimer(self):
         for _ in range(100):
@@ -113,7 +118,8 @@ class TestLowLevelBindings(unittest.TestCase):
                 dntp_conc=self.dntp_conc,
                 dna_conc=self.dna_conc,
                 temp_c=self.temp_c,
-                max_loop=self.max_loop
+                max_loop=self.max_loop,
+                output_structure=True
             )
             wrapper_res = wrappers.calcHomodimer(
                 seq=self.seq1,
@@ -125,6 +131,10 @@ class TestLowLevelBindings(unittest.TestCase):
                 max_loop=self.max_loop
             )
             self.assertEqual(int(binding_res.tm), int(wrapper_res.tm))
+            self.assertEqual(
+                binding_res.ascii_structure,
+                wrapper_res.ascii_structure
+            )
 
     def test_calcHeterodimer(self):
         for _ in range(100):
@@ -137,7 +147,8 @@ class TestLowLevelBindings(unittest.TestCase):
                 dntp_conc=self.dntp_conc,
                 dna_conc=self.dna_conc,
                 temp_c=self.temp_c,
-                max_loop=self.max_loop
+                max_loop=self.max_loop,
+                output_structure=True
             )
             wrapper_res = wrappers.calcHeterodimer(
                 seq1=self.seq1,
@@ -150,6 +161,10 @@ class TestLowLevelBindings(unittest.TestCase):
                 max_loop=self.max_loop
             )
             self.assertEqual(int(binding_res.tm), int(wrapper_res.tm))
+            self.assertEqual(
+                binding_res.ascii_structure,
+                wrapper_res.ascii_structure
+            )
             # Ensure that order of sequences does not matter
             # Should be fixed as of Primer3 2.3.7 update
             binding_12_res = bindings.calcHeterodimer(
@@ -160,7 +175,8 @@ class TestLowLevelBindings(unittest.TestCase):
                 dntp_conc=self.dntp_conc,
                 dna_conc=self.dna_conc,
                 temp_c=self.temp_c,
-                max_loop=self.max_loop
+                max_loop=self.max_loop,
+                output_structure=True
             )
             binding_21_res = bindings.calcHeterodimer(
                 seq1=self.seq1,
@@ -245,7 +261,8 @@ class TestLowLevelBindings(unittest.TestCase):
                 dntp_conc=self.dntp_conc,
                 dna_conc=self.dna_conc,
                 temp_c=self.temp_c,
-                max_loop=self.max_loop
+                max_loop=self.max_loop,
+                output_structure=True
             )
         sleep(0.1)  # Pause for any GC
         em = _getMemUsage()


### PR DESCRIPTION
This adds support for ASCII structure string generation in the bindings for homodimer, heterodimer, and hairpin calculations. For example:

```
>>> import primer3
>>> res = primer3.bindings.calcHeterodimer('CCCCTCCCC', 'GGGGTGGGG', output_structure=True)
>>> print(res.ascii_structure) 
SEQ	    T    
SEQ	CCCC CCCC
STR	GGGG GGGG
STR	    T    
```

If the `output_structure` kwarg is set to `True` for `calcHeterodimer`, `calcHomodimer`, or `calcHairpin`, the ASCII structure will be generated and stored in the `ascii_structure` property of the `ThermoResult` object. 

Addresses request in #28.