### PR TITLE
type hinting, `cython` style update, `pre-commit` `mypy`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,6 @@ repos:
     rev: v4.4.0
     hooks:
     -   id: double-quote-string-fixer
-    -   id: check-yaml
-        exclude: ((develop|environment).devenv.yml|meta.yaml)
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
 -   repo: https://github.com/pycqa/isort
@@ -26,8 +24,8 @@ repos:
     rev: v2.0.1
     hooks:
     -   id: autopep8
-# -   repo: https://github.com/pre-commit/mirrors-mypy
-#     rev: v0.991
-#     hooks:
-#     -   id: mypy
-#         additional_dependencies: [types-PyYAML, types-certifi, types-python-dateutil]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.991
+    hooks:
+    -   id: mypy
+        additional_dependencies: [types-certifi]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#
+# type: ignore
 # primer3-py documentation build configuration file, created by
 # sphinx-quickstart on Tue Nov 25 12:19:07 2014.
 #

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -25,7 +25,7 @@ oligonucleotide thermodynamics library.
 
 import os
 
-from . import (
+from . import (  # type: ignore
     bindings,
     primerdesign,
     thermoanalysis,
@@ -70,7 +70,7 @@ def includes():
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = 'Copyright 2014-2020, Ben Pruitt & Nick Conway; Wyss Institute'
 __license__ = 'GPLv2'
-__version__ = '1.0.0-alpha.2'
+__version__ = '1.0.0-alpha.3'
 
 __all__ = [
     # Low-level Tm-only bindings

--- a/primer3/bindings.py
+++ b/primer3/bindings.py
@@ -35,8 +35,14 @@ and/or Cython modules directly. See the docs for more details.
 
 import os
 from os.path import join as pjoin
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    Union,
+)
 
-from . import (
+from . import (  # type: ignore
     primerdesign,
     thermoanalysis,
 )
@@ -52,27 +58,41 @@ primerdesign.loadThermoParams(pjoin(LIBPRIMER3_PATH, 'primer3_config/'))
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Low level bindings ~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 
+Str_Bytes_T = Union[str, bytes]
+
 _THERMO_ANALYSIS = thermoanalysis.ThermoAnalysis()
 
 
 def _setThermoArgs(
-    mv_conc=50, dv_conc=0, dntp_conc=0.8, dna_conc=50,
-    temp_c=37, max_loop=30, tm_method='santalucia',
-    salt_corrections_method='santalucia', **kwargs,
+        mv_conc: Union[float, int] = 50.,
+        dv_conc: Union[float, int] = 0.,
+        dntp_conc: Union[float, int] = 0.8,
+        dna_conc: Union[float, int] = 50.,
+        temp_c: Union[float, int] = 37.,
+        max_loop: int = 30,
+        tm_method: str = 'santalucia',
+        salt_corrections_method: str = 'santalucia',
+        **kwargs,
 ):
     _THERMO_ANALYSIS.mv_conc = float(mv_conc)
     _THERMO_ANALYSIS.dv_conc = float(dv_conc)
     _THERMO_ANALYSIS.dntp_conc = float(dntp_conc)
     _THERMO_ANALYSIS.dna_conc = float(dna_conc)
     _THERMO_ANALYSIS.temp = float(temp_c)
-    _THERMO_ANALYSIS.max_loop = float(max_loop)
+    _THERMO_ANALYSIS.max_loop = int(max_loop)
     _THERMO_ANALYSIS.tm_method = tm_method
     _THERMO_ANALYSIS.salt_correction_method = salt_corrections_method
 
 
 def calcHairpin(
-    seq, mv_conc=50.0, dv_conc=0.0, dntp_conc=0.8, dna_conc=50.0,
-    temp_c=37, max_loop=30, output_structure=False,
+        seq: str,
+        mv_conc: Union[float, int] = 50.0,
+        dv_conc: Union[float, int] = 0.0,
+        dntp_conc: Union[float, int] = 0.8,
+        dna_conc: Union[float, int] = 50.0,
+        temp_c: Union[float, int] = 37.,
+        max_loop: int = 30,
+        output_structure: bool = False,
 ):
     ''' Calculate the hairpin formation thermodynamics of a DNA sequence.
 
@@ -83,12 +103,11 @@ def calcHairpin(
 
     Args:
         seq (str): DNA sequence to analyze for hairpin formation
-
-        mv_conc (float/int, optional): Monovalent cation conc. (mM)
-        dv_conc (float/int, optional): Divalent cation conc. (mM)
-        dntp_conc (float/int, optional): dNTP conc. (mM)
-        dna_conc (float/int, optional): DNA conc. (nM)
-        temp_c (int, optional): Simulation temperature for dG (Celsius)
+        mv_conc: Monovalent cation conc. (mM)
+        dv_conc: Divalent cation conc. (mM)
+        dntp_conc: dNTP conc. (mM)
+        dna_conc: DNA conc. (nM)
+        temp_c: Simulation temperature for dG (Celsius)
         max_loop(int, optional): Maximum size of loops in the structure
         output_structure (bool) : If `True`, the ASCII dimer structure is saved
 
@@ -105,8 +124,14 @@ def calcHairpin(
 
 
 def calcHomodimer(
-    seq, mv_conc=50, dv_conc=0, dntp_conc=0.8, dna_conc=50,
-    temp_c=37, max_loop=30, output_structure=False,
+    seq: str,
+    mv_conc: Union[float, int] = 50.,
+    dv_conc: Union[float, int] = 0.,
+    dntp_conc: Union[float, int] = 0.8,
+    dna_conc: Union[float, int] = 50.,
+    temp_c: Union[float, int] = 37.,
+    max_loop: int = 30,
+    output_structure: bool = False,
 ):
     ''' Calculate the homodimerization thermodynamics of a DNA sequence.
 
@@ -116,17 +141,15 @@ def calcHomodimer(
     primer3/src/libnano/thal.h:50).
 
     Args:
-        seq (str)                       : DNA sequence to analyze for homodimer
-                                          formation calculations
-
-        mv_conc (float/int, optional)   : Monovalent cation conc. (mM)
-        dv_conc (float/int, optional)   : Divalent cation conc. (mM)
-        dntp_conc (float/int, optional) : dNTP conc. (mM)
-        dna_conc (float/int, optional)  : DNA conc. (nM)
-        temp_c (int, optional)          : Simulation temperature for dG (C)
-        max_loop (int, optional)        : Maximum size of loops in the
-                                          structure
-        output_structure (bool) : If `True`, the ASCII dimer structure is saved
+        seq: DNA sequence to analyze for homodimer formation calculations
+        mv_conc: Monovalent cation conc. (mM)
+        dv_conc: Divalent cation conc. (mM)
+        dntp_conc: dNTP conc. (mM)
+        dna_conc: DNA conc. (nM)
+        temp_c: Simulation temperature for dG (Celsius)
+        max_loop: Maximum size of loops in the structure
+        output_structure: If `True`, the ASCII dimer structure
+            is saved
 
     Returns:
         A `ThermoResult` object with thermodynamic characteristics of the
@@ -141,9 +164,15 @@ def calcHomodimer(
 
 
 def calcHeterodimer(
-    seq1, seq2, mv_conc=50, dv_conc=0, dntp_conc=0.8,
-    dna_conc=50, temp_c=37, max_loop=30,
-    output_structure=False,
+    seq1: str,
+    seq2: str,
+    mv_conc: Union[float, int] = 50.,
+    dv_conc: Union[float, int] = 0.,
+    dntp_conc: Union[float, int] = 0.8,
+    dna_conc: Union[float, int] = 50.,
+    temp_c: Union[float, int] = 37.,
+    max_loop: int = 30,
+    output_structure: bool = False,
 ):
     ''' Calculate the heterodimerization thermodynamics of two DNA sequences.
 
@@ -153,18 +182,15 @@ def calcHeterodimer(
     primer3/src/libnano/thal.h:50).
 
     Args:
-        seq1 (str)              : First DNA sequence to analyze for heterodimer
-                                  formation
-        seq2 (str)              : Second DNA sequence to analyze for
-                                  heterodimer formation
-
-        mv_conc (float/int)     : Monovalent cation conc. (mM)
-        dv_conc (float/int)     : Divalent cation conc. (mM)
-        dntp_conc (float/int)   : dNTP conc. (mM)
-        dna_conc (float/int)    : DNA conc. (nM)
-        temp_c (int)            : Simulation temperature for dG (Celsius)
-        max_loop(int)           : Maximum size of loops in the structure
-        output_structure (bool) : If `True`, the ASCII dimer structure is saved
+        seq1: First DNA sequence to analyze for heterodimer formation
+        seq2: Second DNA sequence to analyze for heterodimer formation
+        mv_conc: Monovalent cation conc. (mM)
+        dv_conc: Divalent cation conc. (mM)
+        dntp_conc: dNTP conc. (mM)
+        dna_conc: DNA conc. (nM)
+        temp_c: Simulation temperature for dG (Celsius)
+        max_loop: Maximum size of loops in the structure
+        output_structure: If `True`, the ASCII dimer structure is saved
 
     Returns:
         A `ThermoResult` object with thermodynamic characteristics of the
@@ -183,9 +209,15 @@ def calcHeterodimer(
 
 
 def calcEndStability(
-    seq1, seq2, mv_conc=50, dv_conc=0, dntp_conc=0.8,
-    dna_conc=50, temp_c=37, max_loop=30,
-):
+        seq1: str,
+        seq2: str,
+        mv_conc: Union[float, int] = 50.,
+        dv_conc: Union[float, int] = 0.,
+        dntp_conc: Union[float, int] = 0.8,
+        dna_conc: Union[float, int] = 50,
+        temp_c: Union[float, int] = 37,
+        max_loop: int = 30,
+) -> thermoanalysis.ThermoResult:
     ''' Calculate the 3' end stability of DNA sequence `seq1` against DNA
     sequence `seq2`.
 
@@ -195,19 +227,15 @@ def calcEndStability(
     primer3/src/libnano/thal.h:50).
 
     Args:
-        seq1 (str)                        : DNA sequence to analyze for 3' end
-                                            hybridization against the target
-                                            sequence
-        seq2 (str)                        : Target DNA sequence to analyze for
-                                            seq1 3' end hybridization
-
-        mv_conc (float/int, optional)     : Monovalent cation conc. (mM)
-        dv_conc (float/int, optional)     : Divalent cation conc. (mM)
-        dntp_conc (float/int, optional)   : dNTP conc. (mM)
-        dna_conc (float/int, optional)    : DNA conc. (nM)
-        temp_c (int, optional)            : Simulation temperature for dG (C)
-        max_loop(int, optional)           : Maximum size of loops in the
-                                            structure
+        seq1: DNA sequence to analyze for 3' end  hybridization against the
+            target sequence
+        seq2: Target DNA sequence to analyze for seq1 3' end hybridization
+        mv_conc: Monovalent cation conc. (mM)
+        dv_conc: Divalent cation conc. (mM)
+        dntp_conc: dNTP conc. (mM)
+        dna_conc: DNA conc. (nM)
+        temp_c: Simulation temperature for dG (Celsius)
+        max_loop: Maximum size of loops in the structure
 
     Returns:
         A `ThermoResult` object with thermodynamic characteristics of the
@@ -222,10 +250,15 @@ def calcEndStability(
 
 
 def calcTm(
-    seq, mv_conc=50, dv_conc=0, dntp_conc=0.8, dna_conc=50,
-    max_nn_length=60, tm_method='santalucia',
-    salt_corrections_method='santalucia',
-):
+        seq: str,
+        mv_conc: Union[float, int] = 50.,
+        dv_conc: Union[float, int] = 0.,
+        dntp_conc: Union[float, int] = 0.8,
+        dna_conc: Union[float, int] = 50,
+        max_nn_length: int = 60,
+        tm_method: str = 'santalucia',
+        salt_corrections_method: str = 'santalucia',
+) -> float:
     ''' Calculate the melting temperature (Tm) of a DNA sequence.
 
     Note that NN thermodynamics will be used to calculate the Tm of sequences
@@ -235,60 +268,58 @@ def calcTm(
         Tm = 81.5 + 16.6(log10([mv_conc])) + 0.41(%GC) - 600/length
 
     Args:
-        seq (str)                               : DNA sequence
-        mv_conc (float/int, optional)           : Monovalent cation conc. (mM)
-        dv_conc (float/int, optional)           : Divalent cation conc. (mM)
-        dntp_conc (float/int, optional)         : dNTP conc. (mM)
-        dna_conc (float/int, optional)          : DNA conc. (nM)
-        max_nn_length (int, optional)           : Maximum length for
-                                                  nearest-neighbor calcs
-        tm_method (str, optional)               : Tm calculation method
-                                                  (breslauer or santalucia)
-        salt_corrections_method (str, optional) : Salt correction method
-                                                  (schildkraut, owczarzy,
-                                                  santalucia)
+        seq: DNA sequence
+        mv_conc: Monovalent cation conc. (mM)
+        dv_conc: Divalent cation conc. (mM)
+        dntp_conc: dNTP conc. (mM)
+        dna_conc: DNA conc. (nM)
+        temp_c: Simulation temperature for dG (Celsius)
+        max_nn_length: Maximum length for nearest-neighbor calcs
+        tm_method: Tm calculation method (breslauer or santalucia)
+        salt_corrections_method: Salt correction method (schildkraut, owczarzy,
+            santalucia)
 
     Returns:
         The melting temperature in degrees Celsius (float).
-
     '''
     _setThermoArgs(**locals())
     return _THERMO_ANALYSIS.calcTm(seq)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Tm-only aliases ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
-def calcHairpinTm(*args, **kwargs):
+def calcHairpinTm(*args, **kwargs) -> float:
     return calcHairpin(*args, **kwargs).tm
 
 
-def calcHomodimerTm(*args, **kwargs):
+def calcHomodimerTm(*args, **kwargs) -> float:
     return calcHomodimer(*args, **kwargs).tm
 
 
-def calcHeterodimerTm(*args, **kwargs):
+def calcHeterodimerTm(*args, **kwargs) -> float:
     return calcHeterodimer(*args, **kwargs).tm
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Design bindings ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 
 def designPrimers(
-    seq_args, global_args=None, misprime_lib=None,
-    mishyb_lib=None, debug=False,
-):
-    ''' Run the Primer3 design process.
+        seq_args: Dict[str, Any],
+        global_args: Optional[Dict[str, Any]] = None,
+        misprime_lib: Optional[Dict[Str_Bytes_T, Str_Bytes_T]] = None,
+        mishyb_lib: Optional[Dict[Str_Bytes_T, Str_Bytes_T]] = None,
+        debug: bool = False,
+) -> Dict[str, Any]:
+    '''Run the Primer3 design process.
 
     If the global args have been previously set (either by a pervious
     `designPrimers` call or by a `setGlobals` call), `designPrimers` may be
     called with seqArgs alone (as a means of optimization).
 
     Args:
-        seq_args (dict)               : Primer3 sequence/design args as per
-                                        Primer3 docs
-
-        global_args (dict, optional)  : Primer3 global args as per Primer3 docs
-        misprime_lib (dict, optional) : `Sequence name: sequence` dictionary
-                                        for mispriming checks.
-        mishyb_lib (dict, optional)   : `Sequence name: sequence` dictionary
-                                        for mishybridization checks.
+        seq_args: Primer3 sequence/design args as per Primer3 docs
+        global_args: Primer3 global args as per Primer3 docs
+        misprime_lib: `Sequence name: sequence` dictionary for mispriming
+            checks.
+        mishyb_lib: `Sequence name: sequence` dictionary for mishybridization
+            checks.
 
     Returns:
         A dictionary of Primer3 results (should be identical to the expected
@@ -307,30 +338,32 @@ be used in cases where performance or customiziation are of high priority.
 '''
 
 
-def setP3Globals(global_args, misprime_lib=None, mishyb_lib=None):
+def setP3Globals(
+        global_args: Dict[str, Any],
+        misprime_lib: Optional[Dict[Str_Bytes_T, Str_Bytes_T]] = None,
+        mishyb_lib: Optional[Dict[Str_Bytes_T, Str_Bytes_T]] = None,
+) -> None:
     ''' Set the Primer3 global args and misprime/mishyb libraries.
 
     Args:
-        global_args (dict)            : Primer3 global parameters as per
-                                        Primer3 docs
-
-        misprime_lib (dict, optional) : ``<Sequence name: sequence>`` dict
-                                        for mispriming checks.
-        mishyb_lib (dict, optional)   : ``<Sequence name: sequence>`` dict
-                                        for mishybridization checks.
+        global_args: Primer3 global parameters as per Primer3 docs
+        misprime_lib: ``<Sequence name: sequence>`` dict for mispriming checks.
+        mishyb_lib: ``<Sequence name: sequence>`` dict for mishybridization
+            checks.
 
     Returns:
         ``None``
-
     '''
     primerdesign.setGlobals(global_args, misprime_lib, mishyb_lib)
 
 
-def setP3SeqArgs(seq_args):
+def setP3SeqArgs(
+        seq_args: Dict[str, Any],
+) -> None:
     ''' Set the Primer3 sequence / design arguments.
 
     Args:
-        seq_args (dict)     : Primer3 seq/design args as per Primer3 docs
+        seq_args: Primer3 seq/design args as per Primer3 docs
 
     Returns:
         ``None``
@@ -339,15 +372,15 @@ def setP3SeqArgs(seq_args):
     primerdesign.setSeqArgs(seq_args)
 
 
-def runP3Design(debug=False):
+def runP3Design(debug: bool = False) -> None:
     ''' Start the Primer3 design process, return a dict of the Primer3 output.
 
     The global parameters and seq args must have been previously set prior to
     this call (raises IOError).
 
     Args:
-        debug (bool, optional)  : If ``True``, prints the received design
-                                  params to stderr for debugging purposes
+        debug: If ``True``, prints the received design params to stderr for
+            debugging purposes
 
     Returns:
         A dictionary of Primer3 results (should be identical to the expected

--- a/primer3/src/primerdesign_py.c
+++ b/primer3/src/primerdesign_py.c
@@ -64,7 +64,7 @@ PyDoc_STRVAR(loadThermoParams__doc__,
 
 PyDoc_STRVAR(setGlobals__doc__,
 "Set the Primer3 global args and add a mispriming and/or mishyb libary\n\n"
-"global_args: dictionary of Primer3 args\n"
+"global_args: dictionary of Primer3 global args\n"
 "misprime_lib: mispriming library dictionary\n"
 "mishyb_lib: mishybridization library dictionary\n"
 );

--- a/primer3/thermoanalysis.pxd
+++ b/primer3/thermoanalysis.pxd
@@ -54,12 +54,14 @@ cdef extern from "thal.h":
 
 
 
-    void thal(  const unsigned char*,
-                const unsigned char*,
-                const thal_args*,
-                thal_results*,
-                const int,
-                char*)
+    void thal(
+        const unsigned char*,
+        const unsigned char*,
+        const thal_args*,
+        thal_results*,
+        const int,
+        char*,
+    )
 
     int get_thermodynamic_values(const char*, thal_results *)
 
@@ -78,34 +80,54 @@ cdef class ThermoAnalysis:
     cdef public int _salt_correction_method
 
     cdef inline ThermoResult calcHeterodimer_c(
-        ThermoAnalysis self,
-        unsigned char*s1,
-        unsigned char* s2,
-        bint output_structure
+            ThermoAnalysis self,
+            unsigned char* s1,
+            unsigned char* s2,
+            bint output_structure
     )
 
     cdef inline ThermoResult calcHomodimer_c(
-        ThermoAnalysis self,
-        unsigned char*s1,
-        bint output_structure
+            ThermoAnalysis self,
+            unsigned char* s1,
+            bint output_structure
     )
 
     cdef inline ThermoResult calcHairpin_c(
-        ThermoAnalysis self,
-        unsigned char*s1,
-        bint output_structure
+            ThermoAnalysis self,
+            unsigned char* s1,
+            bint output_structure
     )
 
-    cdef inline ThermoResult calcEndStability_c(ThermoAnalysis self,
-                                                unsigned char*s1,
-                                                unsigned char* s2)
+    cdef inline ThermoResult calcEndStability_c(
+            ThermoAnalysis self,
+            unsigned char* s1,
+            unsigned char* s2,
+    )
 
     cdef inline double calcTm_c(ThermoAnalysis self, char* s1)
 
-    cpdef calcHeterodimer(ThermoAnalysis self, seq1, seq2, output_structure=*)
+    cpdef ThermoResult calcHeterodimer(
+            ThermoAnalysis self,
+            object seq1,
+            object seq2,
+            bint output_structure = *,
+    )
 
-    cpdef calcHomodimer(ThermoAnalysis self, seq1, output_structure=*)
+    cpdef ThermoResult calcHomodimer(
+            ThermoAnalysis self,
+            object seq1,
+            bint output_structure = *,
+    )
 
-    cpdef calcHairpin(ThermoAnalysis self, seq1, output_structure=*)
+    cpdef ThermoResult calcHairpin(
+            ThermoAnalysis self,
+            object seq1,
+            bint output_structure = *,
+    )
 
-    cpdef misprimingCheck(ThermoAnalysis self, putative_seq, sequences,  double tm_threshold)
+    cpdef tuple misprimingCheck(
+            ThermoAnalysis self,
+            object putative_seq,
+            object sequences,
+            double tm_threshold,
+    )

--- a/setup.py
+++ b/setup.py
@@ -245,9 +245,36 @@ if ('build_ext' in sys.argv or 'install' in sys.argv):
         p3Build()
         P3_BUILT = True
 
+
+def try_cythonize(extension_list, *args, **kwargs):
+    '''
+    Light cythonize wrapper
+    '''
+    try:
+        from Cython.Build import cythonize
+    except (ImportError, ModuleNotFoundError):
+        def cythonize(x, **kwargs):
+            return x
+
+    cython_compiler_directives = dict(
+        # always_allow_keywords=False,
+        # boundscheck=False,
+        # embedsignature=False,
+        # initializedcheck=False,
+        # wraparound=False,
+        language_level='3',
+        c_string_encoding='utf-8',
+    )
+
+    return cythonize(
+        extension_list,
+        compiler_directives=cython_compiler_directives,
+    )
+
+
 setup(
     name='primer3-py',
-    version='1.0.0-alpha.2',
+    version='1.0.0-alpha.3',
     license='GPLv2',
     author='Ben Pruitt, Nick Conway',
     author_email='bpruittvt@gmail.com',
@@ -258,18 +285,17 @@ setup(
         'Programming Language :: C',
         'Programming Language :: Cython',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
     ],
     packages=['primer3'],
-    ext_modules=[primerdesign_ext, thermoanalysis_ext],
+    ext_modules=[primerdesign_ext] + try_cythonize([thermoanalysis_ext]),
     package_data={'primer3': PACKAGE_FPS},
     cmdclass={
         'install_lib': CustomInstallLib,
@@ -277,6 +303,6 @@ setup(
         'build_clib': CustomBuildClib,
     },
     test_suite='tests',
-    setup_requires=['Cython', 'setuptools>=18.0'],
+    setup_requires=['Cython', 'setuptools>=65.6.3'],
     zip_safe=False,
 )

--- a/tests/checkdatasets.py
+++ b/tests/checkdatasets.py
@@ -1,9 +1,33 @@
+# Copyright (C) 2014-2020. Ben Pruitt & Nick Conway; Wyss Institute
+# See LICENSE for full GPLv2 license.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+'''
+tests.checkdatasets
+~~~~~~~~~~~~~~~~~~~
+'''
 import glob
 import json
 import os
 import os.path
 import subprocess
 import sys
+from typing import (
+    Any,
+    Dict,
+)
 
 import click
 
@@ -18,13 +42,28 @@ extra = [dirname(dirname(os.path.abspath(__file__)))]
 sys.path = extra + sys.path
 
 
-def precision(x):
+def precision(x: float) -> float:
     '''Round the precision of floats to make comparisons exact
+
+    Args:
+        x: Float to round
+
+    Returns:
+        float rounded to 2 decimal places
     '''
     return round(x, 2)
 
 
-def todict_tr(x):
+def todict_tr(x: ThermoResult) -> Dict[str, Any]:
+    '''Convert ``ThermoResult`` instance to a dictionary.
+    Round float values for readability
+
+    Args:
+        x: ``ThermoResult`` instance
+
+    Returns:
+        Dictionary form of a ``ThermoResult``
+    '''
     return {
         'structure_found': x.structure_found,
         'tm': precision(x.tm),
@@ -34,7 +73,15 @@ def todict_tr(x):
     }
 
 
-def todict_ta(x):
+def todict_ta(x: ThermoAnalysis) -> Dict[str, Any]:
+    '''Convert ``ThermoAnalysis`` instance to a dictionary.
+
+    Args:
+        x: ``ThermoAnalysis`` instance
+
+    Returns:
+        Dictionary form of a ``ThermoAnalysis``
+    '''
     return {
         'mv_conc': x.mv_conc,
         'dv_conc': x.dv_conc,
@@ -50,11 +97,16 @@ def todict_ta(x):
     }
 
 
-def gitHash():
+def git_hash() -> str:
+    '''
+    Returns:
+        Git hash of repo or NA if not available
+    '''
     try:
         with open(os.devnull, 'wb') as devnull:
             hash_str = subprocess.check_output(
-                ['git', 'rev-parse', '--short', 'HEAD'], stderr=devnull,
+                ['git', 'rev-parse', '--short', 'HEAD'],
+                stderr=devnull,
             )
         return hash_str.strip().decode('utf8')
     except BaseException:
@@ -62,7 +114,12 @@ def gitHash():
 # end def
 
 
-def createDataSet():
+def create_data_set() -> Dict[str, Any]:
+    '''Create data sets for testing
+
+    Returns:
+        Dictionary of test dataset dictionaries
+    '''
     seq1 = 'GGGGCCCCCCAAATTTTTT'
     seq2 = 'AAAAAATTTGGCCCCAAA'
 
@@ -77,39 +134,51 @@ def createDataSet():
     for test in tests:
         f = getattr(ta, test[0])
         res = f(*test[1:])
-        # print(test[0])
         if isinstance(res, ThermoResult):
             cases.append([test, todict_tr(res)])
         else:
             cases.append([test, res])
-    # end for
     out = {
         'thermoanalysis': todict_ta(ta),
         'cases': cases,
     }
-    # import pprint
-    # pprint.pprint(out)
     return out
-# end def
 
 
-def dumpDataSet(x):
+def dump_data_set(x: Dict[str, Any]) -> str:
+    '''
+    Dump data set to a JSON file with the data time and git hash
+
+    Args:
+        x: Data set dictionary to dump
+
+    Returns:
+        Filename formatted in form::
+
+        `primer3_precision_<date>_<githash>_<OS-platform>_<Python-version>.json`
+
+    '''
     import time
     date_str = time.strftime('%Y-%m-%d-%H-%M-%S', time.gmtime())
-    git_hash = gitHash()
+    git_hash_str = git_hash()
     py_version = '%s.%s.%s' % sys.version_info[0:3]
     platform = sys.platform
     filename = 'primer3_precision_%s_%s_%s_%s.json' % (
-        date_str, git_hash, platform, py_version,
+        date_str, git_hash_str, platform, py_version,
     )
     with open(filename, 'w') as fd:
         print('dumping')
         json.dump(x, fd)
     return filename
-# end def
 
 
-def readDataSet():
+def read_data_set() -> Dict[str, Any]:
+    '''
+    Read data set JSON file
+
+    Returns:
+        Dictionary of a the first JSON file found in the local directory
+    '''
     files = glob.glob('*.json')
     if len(files) > 0:
         the_file = files[0]
@@ -125,10 +194,22 @@ def readDataSet():
         return out
     else:
         raise OSError('No json file found')
-# end def
 
 
-def compareSets(reference, test_set):
+def compare_sets(
+        reference: Dict[str, Any],
+        test_set: Dict[str, Any],
+) -> bool:
+    '''
+    Compare thermoanalysis datasets
+
+    Args:
+        reference: Reference thermoanalysis dataset
+        test_set: Test thermoanalysis data set
+
+    Returns:
+        True if the same, False otherwise
+    '''
     for k1, v in reference.items():
         if k1 not in test_set:
             return False
@@ -149,23 +230,22 @@ def compareSets(reference, test_set):
                     return False
 
     return True
-# end def
 
 
 @click.command()
 @click.option('--generate', default=False, help='Generate a set')
 def runner(generate):
-    create_dict = createDataSet()
+    create_dict = create_data_set()
     if generate:
-        filename = dumpDataSet(create_dict)
+        filename = dump_data_set(create_dict)
         print('> Dumped data set: %s' % (filename))
     else:
         print('> Comparing reference and current revisions')
-        print('\t- Current git hash: %s' % (gitHash()))
+        print('\t- Current git hash: %s' % (git_hash()))
         print('\t- Current primer3 version: %s' % (p3version))
-        read_dict = readDataSet()
+        read_dict = read_data_set()
         print('\t- Is the reference set equal to the current revisions set?')
-        are_equal = compareSets(read_dict, create_dict)
+        are_equal = compare_sets(read_dict, create_dict)
         print('\t\t%s' % (str(are_equal)))
 
 

--- a/tests/test_thermoanalysis.py
+++ b/tests/test_thermoanalysis.py
@@ -15,8 +15,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 '''
-test_thermoanalysis
-~~~~~~~~~~~~~~~~~~~
+tests.test_thermoanalysis
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Unit tests for the primer3-py low level thermodynamic calculation bindings.
 
@@ -32,7 +32,7 @@ from time import sleep
 try:
     import resource
 except (ImportError, ModuleNotFoundError):  # For Windows compatibility
-    resource = None
+    resource = None  # type: ignore
 
 from primer3 import (
     bindings,
@@ -41,13 +41,13 @@ from primer3 import (
 
 
 def _getMemUsage():
-    """ Get current process memory usage in bytes """
+    ''' Get current process memory usage in bytes '''
     return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
 
 
 @unittest.skipIf(
     sys.platform == 'win32',
-    "Windows doesn't support resource module and wrappers",
+    'Windows does not support resource module and wrappers',
 )
 class TestLowLevelBindings(unittest.TestCase):
 
@@ -68,7 +68,7 @@ class TestLowLevelBindings(unittest.TestCase):
         self.max_loop = random.randint(10, 30)
 
     def test_calcTm(self):
-        for x in range(100):
+        for _ in range(100):
             self.randArgs()
             binding_tm = bindings.calcTm(
                 seq=self.seq1,
@@ -243,7 +243,10 @@ class TestLowLevelBindings(unittest.TestCase):
                     tm_method=tm_method,
                     salt_corrections_method=sc_method,
                 )
-                self.assertEqual(int(binding_tm), int(wrapper_tm))
+                self.assertEqual(
+                    int(binding_tm),
+                    int(wrapper_tm),
+                )
         self.assertRaises(
             ValueError,
             bindings.calcTm,


### PR DESCRIPTION
type hinting of all python and cython code.
cython code style update
cython `property` decorator update
NOTE: `cpdef` code has difficulties with type hinting with `.pxd` file
    
[`mypy`](https://mypy-lang.org) added to `pre-commit` hooks
    
`cythonize` added to `setup.py` to get `language_level=3` compiler directive.  
Python 3.8 to 3.11 only now based on easily available CPython packages in conda channels used during development.

`wrappers.py` and `primerdesign_helpers.c` and updated to remove Python 2 related code

update to 1.0.0-alpha.3