### PR TITLE
Unify global defaults in new `argdefaults.py` module.

### DIFF
--- a/primer3/argdefaults.py
+++ b/primer3/argdefaults.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2014-2023. Ben Pruitt & Nick Conway; Wyss Institute
+# See LICENSE for full GPLv2 license.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+'''
+primer3.argdefaults
+~~~~~~~~~~~~~~~~~~~
+'''
+import dataclasses
+
+
+@dataclasses.dataclass(kw_only=True)
+class Primer3PyArguments:
+    '''Class containing the defaults values for the system
+
+    NOTE: Goal is to match defaults of Primer3web at https://primer3.ut.ee
+    '''
+    mv_conc: float = 50.0
+    dv_conc: float = 1.5
+    dntp_conc: float = 0.6
+    dna_conc: float = 50.0
+    temp_c: float = 37.
+    max_loop: int = 30
+    output_structure: bool = False
+    salt_corrections_method: str = 'santalucia'
+    salt_corrections_method_int: int = 1
+    max_nn_length: int = 60
+    tm_method: str = 'santalucia'
+    tm_method_int: int = 1
+    temp_only: int = 0
+    calc_type_wrapper = 'ANY'
+
+    def todict(self) -> dict:
+        return dataclasses.asdict(self)

--- a/primer3/bindings.py
+++ b/primer3/bindings.py
@@ -46,6 +46,9 @@ from . import (  # type: ignore
     primerdesign,
     thermoanalysis,
 )
+from .argdefaults import Primer3PyArguments
+
+DEFAULT_P3_ARGS = Primer3PyArguments()
 
 # ~~~~~~~ Check to insure that the environment is properly configured ~~~~~~~ #
 
@@ -64,14 +67,14 @@ _THERMO_ANALYSIS = thermoanalysis.ThermoAnalysis()
 
 
 def _setThermoArgs(
-        mv_conc: Union[float, int] = 50.,
-        dv_conc: Union[float, int] = 0.,
-        dntp_conc: Union[float, int] = 0.8,
-        dna_conc: Union[float, int] = 50.,
-        temp_c: Union[float, int] = 37.,
-        max_loop: int = 30,
-        tm_method: str = 'santalucia',
-        salt_corrections_method: str = 'santalucia',
+        mv_conc: Union[float, int] = DEFAULT_P3_ARGS.mv_conc,
+        dv_conc: Union[float, int] = DEFAULT_P3_ARGS.dv_conc,
+        dntp_conc: Union[float, int] = DEFAULT_P3_ARGS.dntp_conc,
+        dna_conc: Union[float, int] = DEFAULT_P3_ARGS.dna_conc,
+        temp_c: Union[float, int] = DEFAULT_P3_ARGS.temp_c,
+        max_loop: int = DEFAULT_P3_ARGS.max_loop,
+        tm_method: str = DEFAULT_P3_ARGS.tm_method,
+        salt_corrections_method: str = DEFAULT_P3_ARGS.salt_corrections_method,
         **kwargs,
 ):
     _THERMO_ANALYSIS.mv_conc = float(mv_conc)
@@ -86,12 +89,12 @@ def _setThermoArgs(
 
 def calcHairpin(
         seq: str,
-        mv_conc: Union[float, int] = 50.0,
-        dv_conc: Union[float, int] = 0.0,
-        dntp_conc: Union[float, int] = 0.8,
-        dna_conc: Union[float, int] = 50.0,
-        temp_c: Union[float, int] = 37.,
-        max_loop: int = 30,
+        mv_conc: Union[float, int] = DEFAULT_P3_ARGS.mv_conc,
+        dv_conc: Union[float, int] = DEFAULT_P3_ARGS.dv_conc,
+        dntp_conc: Union[float, int] = DEFAULT_P3_ARGS.dntp_conc,
+        dna_conc: Union[float, int] = DEFAULT_P3_ARGS.dna_conc,
+        temp_c: Union[float, int] = DEFAULT_P3_ARGS.temp_c,
+        max_loop: int = DEFAULT_P3_ARGS.max_loop,
         output_structure: bool = False,
 ):
     ''' Calculate the hairpin formation thermodynamics of a DNA sequence.
@@ -102,7 +105,7 @@ def calcHairpin(
     (see primer3/src/libnano/thal.h:50).
 
     Args:
-        seq (str): DNA sequence to analyze for hairpin formation
+        seq: DNA sequence to analyze for hairpin formation
         mv_conc: Monovalent cation conc. (mM)
         dv_conc: Divalent cation conc. (mM)
         dntp_conc: dNTP conc. (mM)
@@ -124,14 +127,14 @@ def calcHairpin(
 
 
 def calcHomodimer(
-    seq: str,
-    mv_conc: Union[float, int] = 50.,
-    dv_conc: Union[float, int] = 0.,
-    dntp_conc: Union[float, int] = 0.8,
-    dna_conc: Union[float, int] = 50.,
-    temp_c: Union[float, int] = 37.,
-    max_loop: int = 30,
-    output_structure: bool = False,
+        seq: str,
+        mv_conc: Union[float, int] = DEFAULT_P3_ARGS.mv_conc,
+        dv_conc: Union[float, int] = DEFAULT_P3_ARGS.dv_conc,
+        dntp_conc: Union[float, int] = DEFAULT_P3_ARGS.dntp_conc,
+        dna_conc: Union[float, int] = DEFAULT_P3_ARGS.dna_conc,
+        temp_c: Union[float, int] = DEFAULT_P3_ARGS.temp_c,
+        max_loop: int = DEFAULT_P3_ARGS.max_loop,
+        output_structure: bool = False,
 ):
     ''' Calculate the homodimerization thermodynamics of a DNA sequence.
 
@@ -164,15 +167,15 @@ def calcHomodimer(
 
 
 def calcHeterodimer(
-    seq1: str,
-    seq2: str,
-    mv_conc: Union[float, int] = 50.,
-    dv_conc: Union[float, int] = 0.,
-    dntp_conc: Union[float, int] = 0.8,
-    dna_conc: Union[float, int] = 50.,
-    temp_c: Union[float, int] = 37.,
-    max_loop: int = 30,
-    output_structure: bool = False,
+        seq1: str,
+        seq2: str,
+        mv_conc: Union[float, int] = DEFAULT_P3_ARGS.mv_conc,
+        dv_conc: Union[float, int] = DEFAULT_P3_ARGS.dv_conc,
+        dntp_conc: Union[float, int] = DEFAULT_P3_ARGS.dntp_conc,
+        dna_conc: Union[float, int] = DEFAULT_P3_ARGS.dna_conc,
+        temp_c: Union[float, int] = DEFAULT_P3_ARGS.temp_c,
+        max_loop: int = DEFAULT_P3_ARGS.max_loop,
+        output_structure: bool = False,
 ):
     ''' Calculate the heterodimerization thermodynamics of two DNA sequences.
 
@@ -211,12 +214,12 @@ def calcHeterodimer(
 def calcEndStability(
         seq1: str,
         seq2: str,
-        mv_conc: Union[float, int] = 50.,
-        dv_conc: Union[float, int] = 0.,
-        dntp_conc: Union[float, int] = 0.8,
-        dna_conc: Union[float, int] = 50,
-        temp_c: Union[float, int] = 37,
-        max_loop: int = 30,
+        mv_conc: Union[float, int] = DEFAULT_P3_ARGS.mv_conc,
+        dv_conc: Union[float, int] = DEFAULT_P3_ARGS.dv_conc,
+        dntp_conc: Union[float, int] = DEFAULT_P3_ARGS.dntp_conc,
+        dna_conc: Union[float, int] = DEFAULT_P3_ARGS.dna_conc,
+        temp_c: Union[float, int] = DEFAULT_P3_ARGS.temp_c,
+        max_loop: int = DEFAULT_P3_ARGS.max_loop,
 ) -> thermoanalysis.ThermoResult:
     ''' Calculate the 3' end stability of DNA sequence `seq1` against DNA
     sequence `seq2`.
@@ -251,13 +254,13 @@ def calcEndStability(
 
 def calcTm(
         seq: str,
-        mv_conc: Union[float, int] = 50.,
-        dv_conc: Union[float, int] = 0.,
-        dntp_conc: Union[float, int] = 0.8,
-        dna_conc: Union[float, int] = 50,
-        max_nn_length: int = 60,
-        tm_method: str = 'santalucia',
-        salt_corrections_method: str = 'santalucia',
+        mv_conc: Union[float, int] = DEFAULT_P3_ARGS.mv_conc,
+        dv_conc: Union[float, int] = DEFAULT_P3_ARGS.dv_conc,
+        dntp_conc: Union[float, int] = DEFAULT_P3_ARGS.dntp_conc,
+        dna_conc: Union[float, int] = DEFAULT_P3_ARGS.dna_conc,
+        max_nn_length: int = DEFAULT_P3_ARGS.max_nn_length,
+        tm_method: str = DEFAULT_P3_ARGS.tm_method,
+        salt_corrections_method: str = DEFAULT_P3_ARGS.salt_corrections_method,
 ) -> float:
     ''' Calculate the melting temperature (Tm) of a DNA sequence.
 

--- a/primer3/src/primerdesign_py.c
+++ b/primer3/src/primerdesign_py.c
@@ -42,40 +42,43 @@ function call overhead is of concern.
 // Helper functions for parameter + output parsing
 #include "primerdesign_helpers.h"
 
-#if PY_MAJOR_VERSION >= 3
 /* see http://python3porting.com/cextensions.html */
-    #define MOD_INIT(name) PyMODINIT_FUNC PyInit_##name(void)
-#else
-    #define MOD_INIT(name) PyMODINIT_FUNC init##name(void)
-#endif
+#define MOD_INIT(name) PyMODINIT_FUNC PyInit_##name(void)
+
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 /* module doc string */
-PyDoc_STRVAR(primerdesign__doc__, "Python C API bindings for the Primer3 "
-                                  "design engine\n");
+PyDoc_STRVAR(
+    primerdesign__doc__,
+    "Python C API bindings for the Primer3 design engine\n"
+);
 
 /* function doc strings */
-PyDoc_STRVAR(loadThermoParams__doc__,
-"Load the Primer3 thermodynamic parameters into memory.\n\n"
-"Should only need to be called once on module import\n"
-"path: path to the parameter directory"
+PyDoc_STRVAR(
+    loadThermoParams__doc__,
+    "Load the Primer3 thermodynamic parameters into memory.\n\n"
+    "Should only need to be called once on module import\n"
+    "path: path to the parameter directory"
 );
 
-PyDoc_STRVAR(setGlobals__doc__,
-"Set the Primer3 global args and add a mispriming and/or mishyb libary\n\n"
-"global_args: dictionary of Primer3 global args\n"
-"misprime_lib: mispriming library dictionary\n"
-"mishyb_lib: mishybridization library dictionary\n"
+PyDoc_STRVAR(
+    setGlobals__doc__,
+    "Set the Primer3 global args and add a mispriming and/or mishyb libary\n\n"
+    "global_args: dictionary of Primer3 global args\n"
+    "misprime_lib: mispriming library dictionary\n"
+    "mishyb_lib: mishybridization library dictionary\n"
 );
 
-PyDoc_STRVAR(setSeqArgs__doc__,
-"Set the Primer3 sequence args\n\n"
-"seq_args: dictionary of Primer3 sequence args\n"
+PyDoc_STRVAR(
+    setSeqArgs__doc__,
+    "Set the Primer3 sequence args\n\n"
+    "seq_args: dictionary of Primer3 sequence args\n"
 );
 
-PyDoc_STRVAR(runDesign__doc__,
-"Design primers using the internal Primer3 design engine\n\n"
+PyDoc_STRVAR(
+    runDesign__doc__,
+    "Design primers using the internal Primer3 design engine\n\n"
 );
 
 
@@ -280,25 +283,19 @@ static PyMethodDef primerdesign_methods[] = {
 };
 
 MOD_INIT(primerdesign){
-#if PY_MAJOR_VERSION >= 3
     PyObject* m;
     static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
-        "primerdesign",           /* m_name */
-        primerdesign__doc__,      /* m_doc */
-        -1,                 /* m_size */
-        primerdesign_methods,     /* m_methods */
-        NULL,               /* m_reload */
-        NULL,               /* m_traverse */
-        NULL,               /* m_clear */
-        NULL,               /* m_free */
+        "primerdesign",         /* m_name */
+        primerdesign__doc__,    /* m_doc */
+        -1,                     /* m_size */
+        primerdesign_methods,   /* m_methods */
+        NULL,                   /* m_reload */
+        NULL,                   /* m_traverse */
+        NULL,                   /* m_clear */
+        NULL,                   /* m_free */
     };
     Py_AtExit(&cleanUp);
     m = PyModule_Create(&moduledef);
     return m;
-#else
-    Py_AtExit(&cleanUp);
-    Py_InitModule3("primerdesign", primerdesign_methods, primerdesign__doc__);
-#endif
-
 }

--- a/primer3/thermoanalysis.pxd
+++ b/primer3/thermoanalysis.pxd
@@ -74,10 +74,16 @@ cdef class ThermoResult:
 
 
 cdef class ThermoAnalysis:
-    cdef thal_args thalargs
-    cdef public int max_nn_length
-    cdef public int _tm_method
-    cdef public int _salt_correction_method
+    cdef:
+        thal_args thalargs
+
+        public int max_nn_length
+        public int _tm_method
+        public object _tm_methods_int_dict
+
+        public int _salt_correction_method
+        public object _salt_correction_methods_int_dict
+
 
     cdef inline ThermoResult calcHeterodimer_c(
             ThermoAnalysis self,

--- a/primer3/wrappers.py
+++ b/primer3/wrappers.py
@@ -44,6 +44,10 @@ from typing import (
     Union,
 )
 
+from .argdefaults import Primer3PyArguments
+
+DEFAULT_P3_ARGS = Primer3PyArguments()
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ PRIMER3 WRAPPERS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 
@@ -78,13 +82,13 @@ _salt_corrections_methods = {
 
 def calcTm(
         seq: str,
-        mv_conc: Union[float, int] = 50,
-        dv_conc: Union[float, int] = 0,
-        dntp_conc: Union[float, int] = 0.8,
-        dna_conc: Union[float, int] = 50,
-        max_nn_length: int = 60,
-        tm_method: str = 'santalucia',
-        salt_corrections_method: str = 'santalucia',
+        mv_conc: Union[float, int] = DEFAULT_P3_ARGS.mv_conc,
+        dv_conc: Union[float, int] = DEFAULT_P3_ARGS.dv_conc,
+        dntp_conc: Union[float, int] = DEFAULT_P3_ARGS.dntp_conc,
+        dna_conc: Union[float, int] = DEFAULT_P3_ARGS.dna_conc,
+        max_nn_length: int = DEFAULT_P3_ARGS.max_nn_length,
+        tm_method: str = DEFAULT_P3_ARGS.tm_method,
+        salt_corrections_method: str = DEFAULT_P3_ARGS.salt_corrections_method,
 ) -> float:
     ''' Return the tm of `seq` as a float.
 
@@ -160,7 +164,7 @@ def _parse_ntthal(ntthal_output: bytes) -> THERMORESULT:
     parsed_vals = re.search(_NTTHAL_RE, ntthal_output)
     if parsed_vals:
         ascii_structure = (
-            ntthal_output[ntthal_output.index(b'\n') + 1:].decode('utf-8')
+            ntthal_output[ntthal_output.index(b'\n') + 1:].decode('utf8')
         )
         res = THERMORESULT(
             True,                           # Structure found
@@ -178,16 +182,16 @@ def _parse_ntthal(ntthal_output: bytes) -> THERMORESULT:
 def calcThermo(
         seq1: str,
         seq2: str,
-        calc_type: str = 'ANY',
-        mv_conc: Union[float, int] = 50.,
-        dv_conc: Union[float, int] = 0.,
-        dntp_conc: Union[float, int] = 0.8,
-        dna_conc: Union[float, int] = 50,
-        temp_c: Union[float, int] = 37,
-        max_loop: int = 30,
-        temp_only: bool = False,
+        calc_type: str = DEFAULT_P3_ARGS.calc_type_wrapper,
+        mv_conc: Union[float, int] = DEFAULT_P3_ARGS.mv_conc,
+        dv_conc: Union[float, int] = DEFAULT_P3_ARGS.dv_conc,
+        dntp_conc: Union[float, int] = DEFAULT_P3_ARGS.dntp_conc,
+        dna_conc: Union[float, int] = DEFAULT_P3_ARGS.dna_conc,
+        temp_c: Union[float, int] = DEFAULT_P3_ARGS.temp_c,
+        max_loop: int = DEFAULT_P3_ARGS.max_loop,
+        temp_only: Union[bool, int] = DEFAULT_P3_ARGS.temp_only,
 ) -> THERMORESULT:
-    """Main subprocess wrapper for calls to the ntthal executable.
+    '''Main subprocess wrapper for calls to the ntthal executable.
 
     Args:
         seq1: DNA sequence to analyze for 3' end  hybridization against the
@@ -207,7 +211,7 @@ def calcThermo(
     Returns:
         a named tuple with tm, ds, dh, and dg values or None if no
         structure / complex could be computed.
-    """
+    '''
     args = [
         pjoin(LIBPRIMER3_PATH, 'ntthal'),
         '-a', str(calc_type),
@@ -231,66 +235,181 @@ def calcThermo(
 
 
 def calcHairpin(
-    seq: str,
-    mv_conc=50,
-    dv_conc=0,
-    dntp_conc=0.8,
-    dna_conc=50,
-    temp_c=37,
-    max_loop=30,
-    temp_only=False,
+        seq: str,
+        mv_conc: Union[float, int] = DEFAULT_P3_ARGS.mv_conc,
+        dv_conc: Union[float, int] = DEFAULT_P3_ARGS.dv_conc,
+        dntp_conc: Union[float, int] = DEFAULT_P3_ARGS.dntp_conc,
+        dna_conc: Union[float, int] = DEFAULT_P3_ARGS.dna_conc,
+        temp_c: Union[float, int] = DEFAULT_P3_ARGS.temp_c,
+        max_loop: int = DEFAULT_P3_ARGS.max_loop,
+        temp_only: Union[bool, int] = DEFAULT_P3_ARGS.temp_only,
 ) -> THERMORESULT:
     ''' Return a namedtuple of the dS, dH, dG, and Tm of any hairpin struct
     present.
+
+    Args:
+        seq: DNA sequence to analyze for hairpin formation
+        mv_conc: Monovalent cation conc. (mM)
+        dv_conc: Divalent cation conc. (mM)
+        dntp_conc: dNTP conc. (mM)
+        dna_conc: DNA conc. (nM)
+        temp_c: Simulation temperature for dG (Celsius)
+        max_loop(int, optional): Maximum size of loops in the structure
+        temp_only:
+        temp_only: print only temp to stderr
+
+    Returns:
+       ``THERMORESULT`` tuple
     '''
     return calcThermo(
-        seq, seq, 'HAIRPIN', mv_conc, dv_conc, dntp_conc,
-        dna_conc, temp_c, max_loop, temp_only,
+        seq,
+        seq,
+        'HAIRPIN',
+        mv_conc,
+        dv_conc,
+        dntp_conc,
+        dna_conc,
+        temp_c,
+        max_loop,
+        temp_only,
     )
 
 
 def calcHeterodimer(
-    seq1, seq2, mv_conc=50, dv_conc=0, dntp_conc=0.8,
-    dna_conc=50, temp_c=37, max_loop=30, temp_only=False,
+        seq1: str,
+        seq2: str,
+        mv_conc: Union[float, int] = DEFAULT_P3_ARGS.mv_conc,
+        dv_conc: Union[float, int] = DEFAULT_P3_ARGS.dv_conc,
+        dntp_conc: Union[float, int] = DEFAULT_P3_ARGS.dntp_conc,
+        dna_conc: Union[float, int] = DEFAULT_P3_ARGS.dna_conc,
+        temp_c: Union[float, int] = DEFAULT_P3_ARGS.temp_c,
+        max_loop: int = DEFAULT_P3_ARGS.max_loop,
+        temp_only: Union[bool, int] = DEFAULT_P3_ARGS.temp_only,
 ) -> THERMORESULT:
-    ''' Return a tuple of the dS, dH, dG, and Tm of any predicted heterodimer.
+    '''Returns a tuple of the dS, dH, dG, and Tm of any predicted heterodimer.
+
+    Args:
+        seq1: DNA sequence to analyze for heterodimer formation
+        seq2: DNA sequence to analyze for heterodimer formation
+        mv_conc: Monovalent cation conc. (mM)
+        dv_conc: Divalent cation conc. (mM)
+        dntp_conc: dNTP conc. (mM)
+        dna_conc: DNA conc. (nM)
+        temp_c: Simulation temperature for dG (Celsius)
+        max_loop(int, optional): Maximum size of loops in the structure
+        temp_only:
+        temp_only: print only temp to stderr
+
+    Returns:
+       ``THERMORESULT`` tuple
     '''
     return calcThermo(
-        seq1, seq2, 'ANY', mv_conc, dv_conc, dntp_conc,
-        dna_conc, temp_c, max_loop, temp_only,
+        seq1,
+        seq2,
+        'ANY',
+        mv_conc,
+        dv_conc,
+        dntp_conc,
+        dna_conc,
+        temp_c,
+        max_loop,
+        temp_only,
     )
 
 
 def calcHomodimer(
-    seq, mv_conc=50, dv_conc=0, dntp_conc=0.8,
-    dna_conc=50, temp_c=37, max_loop=30, temp_only=False,
+        seq: str,
+        mv_conc: Union[float, int] = DEFAULT_P3_ARGS.mv_conc,
+        dv_conc: Union[float, int] = DEFAULT_P3_ARGS.dv_conc,
+        dntp_conc: Union[float, int] = DEFAULT_P3_ARGS.dntp_conc,
+        dna_conc: Union[float, int] = DEFAULT_P3_ARGS.dna_conc,
+        temp_c: Union[float, int] = DEFAULT_P3_ARGS.temp_c,
+        max_loop: int = DEFAULT_P3_ARGS.max_loop,
+        temp_only: Union[bool, int] = DEFAULT_P3_ARGS.temp_only,
 ) -> THERMORESULT:
     ''' Return a tuple of the dS, dH, dG, and Tm of any predicted homodimer.
+
+    Args:
+        seq: DNA sequence to analyze for homodimer formation
+        mv_conc: Monovalent cation conc. (mM)
+        dv_conc: Divalent cation conc. (mM)
+        dntp_conc: dNTP conc. (mM)
+        dna_conc: DNA conc. (nM)
+        temp_c: Simulation temperature for dG (Celsius)
+        max_loop(int, optional): Maximum size of loops in the structure
+        temp_only:
+        temp_only: print only temp to stderr
+
+    Returns:
+       ``THERMORESULT`` tuple
     '''
     return calcThermo(
-        seq, seq, 'ANY', mv_conc, dv_conc, dntp_conc,
-        dna_conc, temp_c, max_loop, temp_only,
+        seq,
+        seq,
+        'ANY',
+        mv_conc,
+        dv_conc,
+        dntp_conc,
+        dna_conc,
+        temp_c,
+        max_loop,
+        temp_only,
     )
 
 
 def calcEndStability(
-    seq1, seq2, mv_conc=50, dv_conc=0, dntp_conc=0.8,
-    dna_conc=50, temp_c=37, max_loop=30, temp_only=False,
+        seq1: str,
+        seq2: str,
+        mv_conc: Union[float, int] = DEFAULT_P3_ARGS.mv_conc,
+        dv_conc: Union[float, int] = DEFAULT_P3_ARGS.dv_conc,
+        dntp_conc: Union[float, int] = DEFAULT_P3_ARGS.dntp_conc,
+        dna_conc: Union[float, int] = DEFAULT_P3_ARGS.dna_conc,
+        temp_c: Union[float, int] = DEFAULT_P3_ARGS.temp_c,
+        max_loop: int = DEFAULT_P3_ARGS.max_loop,
+        temp_only: Union[bool, int] = DEFAULT_P3_ARGS.temp_only,
 ) -> THERMORESULT:
-    ''' Return a tuple of the dS, dH, dG, and Tm of any predicted heterodimer.
+    ''' Return a tuple of the dS, dH, dG, and Tm of any predicted heterodimer
+    end stability
+
+    Args:
+        seq1: DNA sequence to analyze for end stability
+        seq2: DNA sequence to analyze for end stability
+        mv_conc: Monovalent cation conc. (mM)
+        dv_conc: Divalent cation conc. (mM)
+        dntp_conc: dNTP conc. (mM)
+        dna_conc: DNA conc. (nM)
+        temp_c: Simulation temperature for dG (Celsius)
+        max_loop(int, optional): Maximum size of loops in the structure
+        temp_only:
+        temp_only: print only temp to stderr
+
+    Returns:
+       ``THERMORESULT`` tuple
     '''
     return calcThermo(
-        seq1, seq2, 'END1', mv_conc, dv_conc, dntp_conc,
-        dna_conc, temp_c, max_loop, temp_only,
+        seq1,
+        seq2,
+        'END1',
+        mv_conc,
+        dv_conc,
+        dntp_conc,
+        dna_conc,
+        temp_c,
+        max_loop,
+        temp_only,
     )
 
 
-def assessOligo(seq) -> Tuple[THERMORESULT, THERMORESULT]:
+def assessOligo(seq: str) -> Tuple[THERMORESULT, THERMORESULT]:
     '''
     Return the thermodynamic characteristics of hairpin/homodimer structures.
 
-    Returns a tuple of namedtuples (hairpin data, homodimer data) in which each
-    individual tuple is structured (dS, dH, dG, Tm).
+    Args:
+        seq: DNA sequence to analyze
+
+    Returns:
+        A tuple of namedtuples (hairpin data, homodimer data) in which each
+        individual tuple is structured (dS, dH, dG, Tm).
 
     '''
     hairpin_out = calcHairpin(seq)
@@ -300,17 +419,32 @@ def assessOligo(seq) -> Tuple[THERMORESULT, THERMORESULT]:
 
 # ~~~~~~~ RUDIMENTARY PRIMER3 MAIN WRAPPER (see Primer3 docs for args) ~~~~~~ #
 def _formatBoulderIO(p3_args: Dict[str, Any]) -> bytes:
+    '''Convert argument dictionary to boulder formatted bytes
+
+    Args:
+        p3_args: primer3 arguments to format boulder style
+
+    Returns:
+        Boulder formatted byte string
+    '''
     boulder_str = ''.join([
         '{}={}\n'.format(k, v) for k, v in
         p3_args.items()
     ])
-    boulder_str += '=\n'
-    return bytes(boulder_str, 'UTF-8')
+    boulder_str = f'{boulder_str}=\n'
+    return boulder_str.encode('utf8')
 
 
-def _parseBoulderIO(boulder_str: bytes) -> Dict[str, str]:
+def _parseBoulderIO(boulder_bytes: bytes) -> Dict[str, str]:
+    '''Convert boulder info to a key/value dictionary
+    Args:
+        boulder_bytes: Bytes of boulder formatted information to parse
+
+    Returns:
+        Dictionary of key/values
+    '''
     data_dict = OrderedDict()
-    for line in boulder_str.decode('utf-8').split('\n'):
+    for line in boulder_bytes.decode('utf8').split('\n'):
         try:
             k, v = line.strip().split('=')
             data_dict[k] = v
@@ -320,6 +454,13 @@ def _parseBoulderIO(boulder_str: bytes) -> Dict[str, str]:
 
 
 def parseMultiRecordBoulderIO(boulder_str: str) -> List[OrderedDict[str, str]]:
+    '''
+    Args:
+        boulder_str: boulder string to parse with multiple records
+
+    Returns:
+        List of OrderedDicts per record
+    '''
     data_dicts = []
     for record in re.split('=\r?\n', boulder_str):
         if record == '':


### PR DESCRIPTION
Goal is to match defaults of Primer3web at https://primer3.ut.ee

added `argdefaults.Primer3PyArguments` to unify default value locations.
Removed `primerdesign_py.c` Python2 legacy code
    
return `ThermoAnalysis.tm_method and `ThermoAnalysis.salt_correction_method` as strings when get as a
property to abstract integer values from developer using the class

removed `ThermoAnalysis.thal_type` as unused in practice and each class method sets the correct value for this argument