### PR TITLE
Remove `PRIMER3HOME` in favor of package-relative paths

### DIFF
--- a/.github/workflows/primer3-py-ci-github-action.yml
+++ b/.github/workflows/primer3-py-ci-github-action.yml
@@ -2,9 +2,6 @@ name: build, pytest and pre-commit
 
 on: [push, pull_request]
 
-env:
-  PRIMER3HOME: "/home/runner/work/primer3-py/primer3-py/primer3/src/libprimer3"
-
 jobs:
   build-linux:
     runs-on: ubuntu-latest

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -24,6 +24,7 @@ oligonucleotide thermodynamics library.
 '''
 
 import os
+from typing import List
 
 from . import (  # type: ignore
     bindings,
@@ -47,24 +48,13 @@ from .bindings import (
 
 LOCAL_DIR = os.path.dirname(os.path.realpath(__file__))
 
-# ~~~~~~~~~ Get / set the environ. variable for the libprimer3 path ~~~~~~~~~ #
 
-if not os.environ.get('PRIMER3HOME'):
-    libprimer3_path = os.path.join(LOCAL_DIR, 'src/libprimer3')
-    if not os.path.exists(libprimer3_path):
-        raise OSError(
-            'PRIMER3HOME environmental variable is not set '
-            'and a path to libprimer3 could not be found: '
-            '<%s>' % libprimer3_path,
-        )
-    os.environ['PRIMER3HOME'] = libprimer3_path
-
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
-
-
-def includes():
-    return [LOCAL_DIR, os.environ['PRIMER3HOME']]
+def includes() -> List[str]:
+    '''
+    Returns:
+        List of directories to include in egg/wheel during packaging
+    '''
+    return [LOCAL_DIR, os.path.join(LOCAL_DIR, 'src', 'libprimer3')]
 
 
 __author__ = 'Ben Pruitt, Nick Conway'

--- a/primer3/bindings.py
+++ b/primer3/bindings.py
@@ -50,13 +50,18 @@ from .argdefaults import Primer3PyArguments
 
 DEFAULT_P3_ARGS = Primer3PyArguments()
 
-# ~~~~~~~ Check to insure that the environment is properly configured ~~~~~~~ #
-
-LIBPRIMER3_PATH = os.environ['PRIMER3HOME']
-
 # ~~~~~~~~~~~~~~~~ Load thermodynamic parameters into memory ~~~~~~~~~~~~~~~~ #
 
-primerdesign.loadThermoParams(pjoin(LIBPRIMER3_PATH, 'primer3_config/'))
+# TODO: remove after update to primer3 >= 2.5.0
+LOCAL_DIR = os.path.dirname(os.path.realpath(__file__))
+THERMO_PATH = pjoin(
+    LOCAL_DIR,
+    'src',
+    'libprimer3',
+    'primer3_config',
+    '',  # Add trailing slash (OS-ind) req'd by primer3 lib
+)
+primerdesign.loadThermoParams(THERMO_PATH)
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Low level bindings ~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 

--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -46,6 +46,7 @@ from libc.stdlib cimport (
 from libc.string cimport strlen
 
 import atexit
+import os.path
 from typing import (
     Any,
     Dict,
@@ -102,12 +103,17 @@ cdef inline bytes _bytes(s):
 
 # ~~~~~~~~~ Load base thermodynamic parameters into memory from file ~~~~~~~~ #
 
+# TODO: remove after update to primer3 >= 2.5.0
 def _loadThermoParams():
     cdef char*           p3_cfg_path_bytes_c
     cdef thal_results    thalres
-    import os
-    libprimer3_path = os.environ.get('PRIMER3HOME')
-    p3_cfg_path = os.path.join(libprimer3_path, 'primer3_config/')
+    p3_cfg_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        'src',
+        'libprimer3',
+        'primer3_config',
+        '',  # Add trailing slash (OS-ind) req'd by primer3 lib
+    )
     p3_cfg_path_bytes = p3_cfg_path.encode('utf-8')
     p3_cfg_path_bytes_c = p3_cfg_path_bytes
     if get_thermodynamic_values(p3_cfg_path_bytes_c, &thalres) != 0:
@@ -670,7 +676,7 @@ cdef class ThermoAnalysis:
             c_ascii_structure = <char *>malloc(
                 (strlen(<const char*>s1) * 2 + 24)
             )
-            c_ascii_structure[0] = '\0';
+            c_ascii_structure[0] = b'\0';
         thal(
             <const unsigned char*> s1,
             <const unsigned char*> s1,

--- a/primer3/wrappers.py
+++ b/primer3/wrappers.py
@@ -50,21 +50,14 @@ DEFAULT_P3_ARGS = Primer3PyArguments()
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ PRIMER3 WRAPPERS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
-
-# ~~~~~~~ Check to insure that the environment is properly configured ~~~~~~~ #
-
+# TODO: remove after update to primer3 >= 2.5.0
 LOCAL_DIR = os.path.dirname(os.path.realpath(__file__))
-
-if not os.environ.get('PRIMER3HOME'):
-    try:
-        os.environ['PRIMER3HOME'] = pjoin(LOCAL_DIR, 'src/libprimer3')
-    except BaseException:
-        raise OSError('PRIMER3HOME environmental variable is not set.')
-LIBPRIMER3_PATH = os.environ['PRIMER3HOME']
-if not os.path.isdir(LIBPRIMER3_PATH):
-    raise OSError(f'Path {LIBPRIMER3_PATH} does not exist')
-
-THERMO_PATH = pjoin(LIBPRIMER3_PATH, 'primer3_config/')
+LIBPRIMER3_PATH = pjoin(LOCAL_DIR, 'src', 'libprimer3')
+THERMO_PATH = pjoin(
+    LIBPRIMER3_PATH,
+    'primer3_config',
+    '',  # Add trailing slash (OS-ind) req'd by primer3 lib
+)
 
 DEV_NULL = open(os.devnull, 'wb')
 
@@ -499,10 +492,7 @@ def designPrimers(
         stdin=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
-    p3_args.setdefault(
-        'PRIMER_THERMODYNAMIC_PARAMETERS_PATH',
-        pjoin(LIBPRIMER3_PATH, 'primer3_config/'),
-    )
+    p3_args.setdefault('PRIMER_THERMODYNAMIC_PARAMETERS_PATH', THERMO_PATH)
     in_str = _formatBoulderIO(p3_args)
     if input_log:
         input_log.write(in_str)


### PR DESCRIPTION
Includes incidental fix in `thermoanalysis.pyx`
- `c_ascii_structure[0] = '\0';` -> `c_ascii_structure[0] = b'\0';`