### PR TITLE
`kw_only` dataclass fix primer3 py arguments

### DIFF
--- a/primer3/argdefaults.py
+++ b/primer3/argdefaults.py
@@ -21,7 +21,7 @@ primer3.argdefaults
 import dataclasses
 
 
-@dataclasses.dataclass(kw_only=True)
+@dataclasses.dataclass()
 class Primer3PyArguments:
     '''Class containing the defaults values for the system
 


### PR DESCRIPTION
remove `kw_only` kwarg for `dataclass` as it is Python 3.10 only