### PR TITLE
code clarity and comments update.  `*_main.c` argument parsing fixes 

### DIFF
--- a/primer3/src/libprimer3/amplicontm_main.c
+++ b/primer3/src/libprimer3/amplicontm_main.c
@@ -161,7 +161,7 @@ main(int argc, char **argv)
          exit(-1);
        }
        i++;
-     } else if (!strncmp("-dmso", argv[i], 3)) { /* concentration of DMSO */
+     } else if (!strncmp("-dmso", argv[i], 5)) { /* primer3-py bug-fix block need to parse 5 characters instead of 3 concentration of DMSO */
        if (i+1 >= argc) {
          /* Missing value */
          fprintf(stderr, msg, argv[0]);
@@ -173,7 +173,7 @@ main(int argc, char **argv)
          exit(-1);
        }
        i++;
-     } else if (!strncmp("-dmso_fact", argv[i], 3)) { /* DMSO correction factor */
+     } else if (!strncmp("-dmso_fact", argv[i], 10)) { /* primer3-py bug-fix block need to parse 10 characters instead of 3 DMSO correction factor */
        if (i+1 >= argc) {
          /* Missing value */
          fprintf(stderr, msg, argv[0]);
@@ -185,7 +185,7 @@ main(int argc, char **argv)
          exit(-1);
        }
        i++;
-     } else if (!strncmp("-formamid", argv[i], 3)) { /* concentration of formamid */
+     } else if (!strncmp("-formamid", argv[i], 9)) { /* primer3-py bug-fix block need to parse 9 characters instead of 3 concentration of formamid */
        if (i+1 >= argc) {
          /* Missing value */
          fprintf(stderr, msg, argv[0]);

--- a/primer3/src/libprimer3/libprimer3.c
+++ b/primer3/src/libprimer3/libprimer3.c
@@ -43,6 +43,16 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+/* NOTE: primer3-py.  This library is C only and does not use C++ as the
+* upstream libprimer3.cc does. It uses the `klib/khash.h` library to do this
+* avoiding C++ complexity and keeping the build for the Cython code simple.
+* this only affects lines that use hash maps such as the **pairs global variable
+* C++ code replaced is intentionally commented out as a reference for future
+* code comparisons. in older code this replaced `std::hash_map` from
+* and `#include <ext/hash_map>` as of primer3 2.6.1 now replaces
+* `std::unordered_map` from `#include <unordered_map>`
+*/
+
 #include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -53,6 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <ctype.h> /* toupper */
 
+/* NOTE: primer3-py specific include to enable C only code for hash maps */
 #include "khash.h"
 
 #include "dpal.h"
@@ -62,7 +73,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 KHASH_MAP_INIT_INT(primer_pair_map, primer_pair *)
 
 /* #define's */
-
 
 /*
  * OPTIMIZE_OK_REGIONS 1 allows _optimize_ok_regions_list() to use the
@@ -111,6 +121,9 @@ KHASH_MAP_INIT_INT(primer_pair_map, primer_pair *)
 #define PR_UNDEFINED_ALIGN_OPT        -100.0
 
 #define TRIMMED_SEQ_LEN(X) ((X)->incl_l)
+
+/* primer3-py additional variable for code clarity */
+#define DO_PRINTOUT 1
 
 typedef struct dpal_arg_holder {
   dpal_args *local;
@@ -1314,7 +1327,7 @@ choose_primers(const p3_global_settings *pa,
   PR_ASSERT(NULL != pa);
   PR_ASSERT(NULL != sa);
 
-  /* NOTE: NC for debugging*/
+  /* NOTE: primer3-py added to debugging arguments `pa` and `sa` */
   if (pa->do_log_settings) {
     FILE* logf_ptr = fopen(pa->log_settings_path, "ab");
     if (logf_ptr == NULL) {
@@ -5064,14 +5077,13 @@ align_thermod(const char *s1,
 {
   int thal_trace=0;
   thal_results r;
-  // thal((const unsigned char *) s1, (const unsigned char *) s2, a, &r, 1, NULL);
   thal(
     (const unsigned char *) s1,
     (const unsigned char *) s2,
     a,
     THL_FAST,
     &r,
-    1
+    DO_PRINTOUT
   );
   if (thal_trace) {
      fprintf(
@@ -5387,7 +5399,7 @@ recalc_primer_sec_struct(
         thal_arg_to_use->any,
         THL_STRUCT,
         &any,
-        1
+        DO_PRINTOUT
       );
       p_rec->self_any = any.temp;
       save_overwrite_sec_struct(&p_rec->self_any_struct, any.sec_struct);
@@ -5399,7 +5411,7 @@ recalc_primer_sec_struct(
         thal_arg_to_use->end1,
         THL_STRUCT,
         &end,
-        1
+        DO_PRINTOUT
       );
       p_rec->self_end = end.temp;
       save_overwrite_sec_struct(&p_rec->self_end_struct, end.sec_struct);
@@ -5411,7 +5423,7 @@ recalc_primer_sec_struct(
         thal_arg_to_use->hairpin_th,
         THL_STRUCT,
         &hair,
-        1
+        DO_PRINTOUT
       );
       p_rec->hairpin_th = hair.temp;
       save_overwrite_sec_struct(&p_rec->hairpin_struct, hair.sec_struct);
@@ -5523,7 +5535,7 @@ recalc_pair_sec_struct(
         thal_arg_to_use->any,
         THL_STRUCT,
         &any,
-        1
+        DO_PRINTOUT
       );
       ppair->compl_any = any.temp;
       save_overwrite_sec_struct(&ppair->compl_any_struct, any.sec_struct);
@@ -5535,7 +5547,7 @@ recalc_pair_sec_struct(
         thal_arg_to_use->end1,
         THL_STRUCT,
         &end1,
-        1
+        DO_PRINTOUT
       );
       ppair->compl_end = end1.temp;
       save_overwrite_sec_struct(&ppair->compl_end_struct, end1.sec_struct);
@@ -5545,7 +5557,7 @@ recalc_pair_sec_struct(
         thal_arg_to_use->end2,
         THL_STRUCT,
         &end2,
-        1
+        DO_PRINTOUT
       ); /* Triinu Please check */
       if (ppair->compl_end < end2.temp) {
         ppair->compl_end = end2.temp;
@@ -5562,7 +5574,7 @@ recalc_pair_sec_struct(
         thal_arg_to_use->end1,
         THL_STRUCT,
         &end3,
-        1
+        DO_PRINTOUT
       );
       if (ppair->compl_end < end3.temp) {
         ppair->compl_end = end3.temp;
@@ -5579,7 +5591,7 @@ recalc_pair_sec_struct(
         thal_arg_to_use->end2,
         THL_STRUCT,
         &end4,
-        1
+        DO_PRINTOUT
       ); /* Triinu Please check */
       if (ppair->compl_end < end4.temp) {
         ppair->compl_end = end4.temp;

--- a/primer3/src/libprimer3/oligotm.c
+++ b/primer3/src/libprimer3/oligotm.c
@@ -324,8 +324,9 @@ oligotm(const  char *s,
   int GC_count = 0;
   const char* d = s;
 
-  /* NOTE: update NC for debugging oligotm_main as the upstream argument parser
-  * has issues/bugs with argument name collisions
+  /* NOTE: primer3-py block for intentionally commented out for debugging
+  * `oligotm_main` as the upstream argument parser has issues/bugs with argument
+  * name collisions
   */
   // printf(
   //   "%f, %f, %f, %f, %f, %f, %f, %f\n",

--- a/primer3/src/libprimer3/oligotm_main.c
+++ b/primer3/src/libprimer3/oligotm_main.c
@@ -121,8 +121,8 @@ main(int argc, char **argv)
     double dmso = 0.0, dmso_fact = 0.6, formamide = 0.0;
     int tm_santalucia=1, salt_corrections=1;
     int i, j, len;
-    // if (argc < 2 || argc > 14) {
-    // update NC argc limit needs to be update to 20 due to 3 new arguments
+    /* primer3-py bug-fix block */
+    /* update argc limit needs to be update to 20 due to 3 new arguments */
     if (argc < 2 || argc > 20) {
       fprintf(stderr, msg, argv[0]);
       fprintf(stderr, "%s", copyright);
@@ -166,7 +166,7 @@ main(int argc, char **argv)
           exit(-1);
         }
         i++;
-      } else if (!strncmp("-d", argv[i], 3)) {
+      } else if (!strncmp("-d", argv[i], 3)) { /* primer3-py bug-fix block need to parse 3 characters instead of 2. conflicts with dm and df params */
         if (i+1 >= argc) {
           /* Missing value */
           fprintf(stderr, msg, argv[0]);
@@ -178,7 +178,7 @@ main(int argc, char **argv)
           exit(-1);
         }
         i++;
-      } else if (!strncmp("-dm", argv[i], 2)) {
+      } else if (!strncmp("-dm", argv[i], 3)) { /* primer3-py bug-fix block need to parse 3 characters instead of 2 */
         if (i+1 >= argc) {
           /* Missing value */
           fprintf(stderr, msg, argv[0]);
@@ -190,7 +190,7 @@ main(int argc, char **argv)
           exit(-1);
         }
         i++;
-      } else if (!strncmp("-df", argv[i], 2)) {
+      } else if (!strncmp("-df", argv[i], 3)) { /* primer3-py bug-fix block need to parse 3 characters instead of 2 */
         if (i+1 >= argc) {
           /* Missing value */
           fprintf(stderr, msg, argv[0]);
@@ -202,7 +202,7 @@ main(int argc, char **argv)
           exit(-1);
         }
         i++;
-      } else if (!strncmp("-fo", argv[i], 2)) {
+      } else if (!strncmp("-fo", argv[i], 3)) { /* primer3-py bug-fix block need to parse 3 characters instead of 2 */
         if (i+1 >= argc) {
           /* Missing value */
           fprintf(stderr, msg, argv[0]);
@@ -253,10 +253,16 @@ main(int argc, char **argv)
   /* input sequence to uppercase */
   seq = argv[i];
   len=strlen(seq);
-  for(j=0;j<len;j++) seq[j]=toupper(seq[j]);
+  for(j=0;j<len;j++) { seq[j]=toupper(seq[j]); }
 
-  tm_calc = oligotm(seq, d, mv, dv, n, dmso, dmso_fact, formamide,
-                    (tm_method_type) tm_santalucia, (salt_correction_type) salt_corrections, -10.0);
+  /* primer3-py note `annealing_temp` argument hard coded to -10.0 by primer3
+  * maintainers */
+  tm_calc = oligotm(
+    seq, d, mv, dv, n, dmso, dmso_fact, formamide,
+    (tm_method_type) tm_santalucia,
+    (salt_correction_type) salt_corrections,
+    -10.0
+  );
   tm = tm_calc.Tm;
 
   if (OLIGOTM_ERROR == tm) {

--- a/primer3/src/libprimer3/p3_seq_lib.c
+++ b/primer3/src/libprimer3/p3_seq_lib.c
@@ -320,7 +320,7 @@ destroy_seq_lib(seq_lib *p)
     }
     free(p->names);
   }
-  // added NC
+  /* primer3-py additional block */
   if (p->rev_compl_seqs != NULL) {
     // Already freed above (the rev_compl_seqs array contains pointers
     // that just point to the seqs array)

--- a/primer3/src/libprimer3/primer3_boulder_main.c
+++ b/primer3/src/libprimer3/primer3_boulder_main.c
@@ -250,7 +250,7 @@ main(int argc, char *argv[])
   }
   global_pa->dump = dump_args ;
 
-  /* Added NC */
+  /* primer3-py additional block for debugging pa and sa variables */
   global_pa->do_log_settings = 0;
   global_pa->log_settings_path = NULL;
 

--- a/primer3/src/libprimer3/read_boulder.c
+++ b/primer3/src/libprimer3/read_boulder.c
@@ -175,7 +175,8 @@ extern double strtod();
    }
 
 
-/* NOTE: NC for fast new-line parsing a character string
+/* NOTE: primer3-py for `in_buffer` parsing for fast new-line parsing a
+* character string
 * Adapted from https://stackoverflow.com/a/17983619 answer by
 * Jeremy Friesner edited 12/4/2015 CC BY-SA license
 */
@@ -206,13 +207,14 @@ read_boulder_record(FILE *file_input,
                     pr_append_str *nonfatal_parse_err,
                     pr_append_str *warnings,
                     read_boulder_record_results *res,
-                    char* in_buffer
+                    char* in_buffer /* primer3-py new argument */
 ) {
   int line_len;
   int tag_len, datum_len;
   int data_found = 0;
   int read_start_codon = 0;
-  char *s, *n, *datum, *task_tmp = NULL;
+  char *n, *datum, *task_tmp = NULL;
+  char *s = NULL;  /* primer3-py update to initialize away compiler warning */
   const char *p;
   pr_append_str *parse_err;
   pr_append_str *non_fatal_err;
@@ -226,6 +228,11 @@ read_boulder_record(FILE *file_input,
 
   non_fatal_err = nonfatal_parse_err;
 
+  /* primer3-py additional block
+  # new logic to enable reading input from the string in
+  * `in_buffer` instead of from the file `file_input` to unify parsing of
+  * input fields to a single block on C code in this function
+  */
   char* cur_line = NULL;
   char* next_line = NULL;
   int did_start_in_buffer_read = 0;
@@ -234,6 +241,7 @@ read_boulder_record(FILE *file_input,
       cur_line = in_buffer;
   }
 
+  /* Conditionally read from `file_input` OR `in_buffer` new lines splits */
   while (
       (
           (file_input != NULL) &&
@@ -243,9 +251,9 @@ read_boulder_record(FILE *file_input,
           ((next_line = strchr(cur_line, '\n')) != NULL) && (strcmp(cur_line, "="))
       )
   ) {
-    /* Added NC */
+    /* primer3-py specific code for reading from `in_buffer` */
     if (next_line) {
-      *next_line = '\0';  // temporarily terminate the current line
+      *next_line = '\0';  /* temporarily terminate the current line */
       s = cur_line;
     }
     /* If we are reading from a settings file, then skip every
@@ -379,7 +387,7 @@ read_boulder_record(FILE *file_input,
         continue;
       }
 
-      /* NOTE: NC Added parsing for LOGGING Input*/
+      /* NOTE: primer3-py Added parsing for LOGGING Input*/
       if (strncmp(s, "DO_LOG_SETTINGS=1", 17) == 0) {
         pa->do_log_settings = 1;
       }
@@ -780,8 +788,9 @@ read_boulder_record(FILE *file_input,
 
   }  /* end while loop */
 
-  /* Check if the record was terminated by "=" */
-  /* Added NC */
+  /* primer3-py additional block
+  * Check if the record was terminated by "="
+  */
   if (in_buffer != NULL) {
     s = cur_line;
   }

--- a/primer3/src/libprimer3/thal.c
+++ b/primer3/src/libprimer3/thal.c
@@ -44,7 +44,7 @@
 #include <setjmp.h>
 #include <ctype.h>
 #include <math.h>
-// #include <unistd.h> COMMENTED OUT BY NC unused and breaks Windows build
+/* #include <unistd.h> primer3-py COMMENTED OUT as is unused and breaks Windows build */
 
 #if defined(__sun)
 #include <ieeefp.h>
@@ -249,20 +249,24 @@ static void traceback(int i, int j, double RT, int* ps1, int* ps2, int maxLoop, 
 static void tracebacku(int*, int, thal_results*);
 
 /* calculates but does not print dimer structure */
+/* primer3-py special function */
 static void calcDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, double t37, thal_results *o);
 
-/* calculates but does not print hairpin structure */
-static void calcHairpin(int* bp, double mh, double ms, int temponly, double temp, thal_results *o);
-
 /* prints ascii output of dimer structure */
+/* primer3-py special function */
 static void drawDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, double t37, thal_results *o);
 
+/* calculates but does not print hairpin structure */
+/* primer3-py special function */
+static void calcHairpin(int* bp, double mh, double ms, int temponly, double temp, thal_results *o);
+
 /* prints ascii output of hairpin structure */
+/* primer3-py special function */
 static void drawHairpin(int* bp, double mh, double ms, int temponly, double temp, thal_results *o);
 
 int trim_trailing_whitespace(char *msg, size_t msg_len);
 
-/* NOTE: Commented out because primer3-py does not use the drawDimer and drawHairpin
+/* NOTE: primer3-py Commented out because does not use the drawDimer and drawHairpin
  * code of upstream primer3 2.6.1 due to the fact it produces different strings
  * under different conditions.  TODO: refactor upstream drawDimer and drawHairpin
  * code to unify the output
@@ -487,12 +491,12 @@ thal(const unsigned char *oligo_f,
      const thal_args *a,
      const thal_mode mode,
      thal_results *o,
-     const int print_output)  /* New arg NC*/
+     const int print_output)  /* primer3-py modification argumen */
 {
   double* SH;
   int i, j;
   int len_f, len_r;
-  // double T1; NC DEL
+  // double T1; primer3-py commented out variable
   int k;
   int *bp;
   unsigned char *oligo2_rev = NULL;
@@ -538,12 +542,12 @@ thal(const unsigned char *oligo_f,
               "Illegal type");
   o->align_end_1 = -1;
   o->align_end_2 = -1;
-  if (oligo_f != NULL && '\0' == *oligo_f) { /* Updated NC 2023.01.09 for type fix */
+  if (oligo_f != NULL && '\0' == *oligo_f) { /* primer3-py bug fix for type */
     strcpy(o->msg, "Empty first sequence");
     o->temp = 0.0;
     return;
   }
-  if (oligo_r != NULL && '\0' == *oligo_r) { /* Updated NC 2023.01.09 for type fix */
+  if (oligo_r != NULL && '\0' == *oligo_r) { /* primer3-py bug fix for type */
     strcpy(o->msg, "Empty second sequence");
     o->temp = 0.0;
     return;
@@ -640,7 +644,6 @@ thal(const unsigned char *oligo_f,
       tracebacku(bp, a->maxLoop, o);
       /* traceback for unimolecular structure */
 
-      /* Commented code is old primer3-py code NC */
       int do_temponly = 0;
       if (mode == THL_FAST) {
         do_temponly = 1;
@@ -648,10 +651,10 @@ thal(const unsigned char *oligo_f,
       if (print_output == 0) {
         calcHairpin(bp, mh, ms, do_temponly, a->temp, o);
       } else {
-        /* NOTE: NC This block is enable code running in
-         * libprimer3.choose_primers to allocate memory for running.  It
+        /* NOTE: primer3-py This block is enable code running in
+         * `libprimer3.choose_primers` to allocate memory for running.  It
          * is that codes resposibility to free the this memory
-         * Thermoanalysis manages its own allocations
+         * `ThermoAnalysis` manages its own allocations
          */
         if ((o->sec_struct == NULL) && (mode == THL_STRUCT))  {
           int seq_struct_str_len = (len1 + len1 + 1) * 4 + 64;
@@ -669,9 +672,6 @@ thal(const unsigned char *oligo_f,
       }
 
     } else if((mode != THL_FAST) && (mode != THL_DEBUG_F) && (mode != THL_STRUCT)) {
-    /* if temponly=1 then return after printing basic therm data */ // updated commented out NC
-    // } else if (a->temponly == 0) { // updated commented out NC
-    // o->no_structure = 1; // updated commented out NC
         fputs("No secondary structure could be calculated\n",stderr);
     }
 
@@ -694,7 +694,7 @@ thal(const unsigned char *oligo_f,
     entropyDPT = safe_recalloc(entropyDPT, len1, len2, o); /* enthalpyDPT is 3D array represented as 1D array */
     initMatrix();
     fillMatrix(a->maxLoop, o);
-    // SHleft = -_INFINITY; NC DEL
+    /* SHleft = -_INFINITY; primer3-py commented out due to unused */
     SH = (double*) safe_malloc(2 * sizeof(double), o);
     /* calculate terminal basepairs */
     bestI = bestJ = 0;
@@ -727,7 +727,7 @@ thal(const unsigned char *oligo_f,
       bestI = bestJ = 0;
       bestI = len1;
       i = len1;
-      // SHleft = -_INFINITY; NC DEL
+      /* SHleft = -_INFINITY; primer3-py commented out due to unused */
       G1 = bestG = _INFINITY;
       for (j = 1; j <= len2; ++j) {
         RSH(i, j, SH);
@@ -741,7 +741,7 @@ thal(const unsigned char *oligo_f,
         }
       }
     }
-    // if (!isFinite(SHleft)) { bestI = bestJ = 1; } NC DEL
+    /* if (!isFinite(SHleft)) { bestI = bestJ = 1; } primer3-py commented out due to unused DEL */
     if (!isFinite(bestG)) { bestI = bestJ = 1; } // LN 594
     RSH(bestI, bestJ, SH);
     dH = EnthalpyDPT(bestI, bestJ)+ SH[1] + dplx_init_H;
@@ -764,8 +764,8 @@ thal(const unsigned char *oligo_f,
       if (print_output == 0) {
         calcDimer(ps1, ps2, SHleft, dH, dS, do_temponly, a->temp, o);
       } else {
-        /* NOTE: NC This block is enable code running in
-         * libprimer3.choose_primers to allocate memory for running.  It
+        /* NOTE: primer3-py This block is enable code running in
+         * `libprimer3.choose_primers` to allocate memory for running.  It
          * is that codes resposibility to free the this memory
          * Thermoanalysis manages its own allocations
          */
@@ -813,16 +813,13 @@ void
 set_thal_default_args(thal_args *a)
 {
   memset(a, 0, sizeof(thal_args));
-  // a->debug = 0; update commented out NC
   a->type = thal_any; /* thal_alignment_type THAL_ANY */
   a->maxLoop = MAX_LOOP;
   a->mv = 50; /* mM */
   a->dv = 0.0; /* mM */
   a->dntp = 0.8; /* mM */
   a->dna_conc = 50; /* nM */
-  // a->temp = 310.15; /* Kelvin */ NC DEL
   a->temp = TEMP_KELVIN; /* Kelvin */
-  // a->temponly = 1; /* return only melting temperature of predicted structure */ update commented out NC
   a->dimer = 1; /* by default dimer structure is calculated */
 }
 
@@ -831,16 +828,13 @@ void
 set_thal_oligo_default_args(thal_args *a)
 {
   memset(a, 0, sizeof(thal_args));
-  // a->debug = 0; update commented out NC
   a->type = thal_any; /* thal_alignment_type THAL_ANY */
   a->maxLoop = MAX_LOOP;
   a->mv = 50; /* mM */
   a->dv = 0.0; /* mM */
   a->dntp = 0.0; /* mM */
   a->dna_conc = 50; /* nM */
-  // a->temp = 310.15; /* Kelvin */ NC DEL
   a->temp = TEMP_KELVIN; /* Kelvin */
-  // a->temponly = 1; /* return only melting temperature of predicted structure */ update commented out NC
   a->dimer = 1; /* by default dimer structure is calculated */
 }
 
@@ -1668,7 +1662,6 @@ maxTM(int i, int j)
   T0 = T1 = -_INFINITY;
   S0 = EntropyDPT(i, j);
   H0 = EnthalpyDPT(i, j);
-  // T0 = (H0 + dplx_init_H) /(S0 + dplx_init_S + RC); /* at current position */ NC DEL
   RSH(i,j,SH);
   T0 = (H0 + dplx_init_H + SH[1]) /(S0 + dplx_init_S + SH[0] + RC); /* at current position */
   if (isFinite(EnthalpyDPT(i - 1, j - 1)) && isFinite(Hs(i - 1, j - 1, 1))) {
@@ -1680,7 +1673,6 @@ maxTM(int i, int j)
     H1 = _INFINITY;
     T1 = (H1 + dplx_init_H) /(S1 + dplx_init_S + RC);
   }
-  // T1 = (H1 + dplx_init_H) /(S1 + dplx_init_S + RC); NC DEL
   if (S1 < MinEntropyCutoff) {
     /* to not give dH any value if dS is unreasonable */
     S1 = MinEntropy;
@@ -1691,7 +1683,6 @@ maxTM(int i, int j)
     S0 = MinEntropy;
     H0 = 0.0;
   }
-  // if ((T1 > T0) || ((S0 > 0) && (H0 > 0))) { /* T1 on suurem */ NC DEL
   if(T1 > T0) {
     EntropyDPT(i, j) = S1;
     EnthalpyDPT(i, j) = H1;
@@ -1742,8 +1733,6 @@ maxTM2(int i, int j)
 static void
 LSH(int i, int j, double* EntropyEnthalpy)
 {
-  // double S1, H1, T1; NC DEL
-  // double S2, H2, T2; NC DEL
   double S1, H1, T1, G1;
   double S2, H2, T2, G2;
   S1 = S2 = -1.0;
@@ -1756,15 +1745,13 @@ LSH(int i, int j, double* EntropyEnthalpy)
   }
   S1 = atPenaltyS(numSeq1[i], numSeq2[j]) + tstack2Entropies[numSeq2[j]][numSeq2[j-1]][numSeq1[i]][numSeq1[i-1]];
   H1 = atPenaltyH(numSeq1[i], numSeq2[j]) + tstack2Enthalpies[numSeq2[j]][numSeq2[j-1]][numSeq1[i]][numSeq1[i-1]];
-  // if(!isFinite(H1)) { NC DEL
-  G1 = H1 - TEMP_KELVIN*S1;
+  G1 = H1 - (TEMP_KELVIN * S1);
   if(!isFinite(H1) || (G1 > 0)) {
     H1 = _INFINITY;
     S1 = -1.0;
     G1 = 1.0;
   }
   /** If there is two dangling ends at the same end of duplex **/
-  // if(isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]]) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) { NC DEL
   if ( (bpIndx(numSeq1[i-1], numSeq2[j-1]) != 1 ) &&
       isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]]) &&
       isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]]) ) {
@@ -1772,7 +1759,6 @@ LSH(int i, int j, double* EntropyEnthalpy)
         dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
     H2 = atPenaltyH(numSeq1[i], numSeq2[j]) + dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +
         dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
-    // if(!isFinite(H2)) { NC DEL
     G2 = H2 - TEMP_KELVIN*S2;
     if(!isFinite(H2) || (G2 > 0)) {
       H2 = _INFINITY;
@@ -1780,26 +1766,21 @@ LSH(int i, int j, double* EntropyEnthalpy)
       G2 = 1.0;
     }
     T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-    // if(isFinite(H1)) { NC DEL
     if(isFinite(H1) && (G1 < 0)) {
       T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-      // if(T1<T2) { NE DEL
       if( (T1 < T2) && (G2 < 0) ) {
         S1 = S2;
         H1 = H2;
         T1 = T2;
       }
-    // } else { NC DEL
     } else if(G2 < 0) {
       S1 = S2;
       H1 = H2;
       T1 = T2;
     }
-  // } else if (isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]])) { NC DEL
   } else if ((bpIndx(numSeq1[i-1], numSeq2[j-1]) != 1) && isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]])) {
     S2 = atPenaltyS(numSeq1[i], numSeq2[j]) + dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
     H2 = atPenaltyH(numSeq1[i], numSeq2[j]) + dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
-    // if(!isFinite(H2)) { NC DEL
     G2 = H2 - TEMP_KELVIN*S2;
     if(!isFinite(H2) || (G2 > 0)) {
       H2 = _INFINITY;
@@ -1807,26 +1788,21 @@ LSH(int i, int j, double* EntropyEnthalpy)
       G2 = 1.0;
     }
     T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-    // if(isFinite(H1)) { NC DEL
     if(isFinite(H1) && (G1 < 0)) {
       T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-      // if (T1 < T2) { NC DEL
       if((T1 < T2) && (G2 < 0)) {
         S1 = S2;
         H1 = H2;
         T1 = T2;
       }
-    // } else { NC DEL
     } else if (G2 < 0){
       S1 = S2;
       H1 = H2;
       T1 = T2;
     }
-  // } else if (isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) { NC DEL
   } else if ((bpIndx(numSeq1[i-1], numSeq2[j-1]) != 1) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
     S2 = atPenaltyS(numSeq1[i], numSeq2[j]) + dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
     H2 = atPenaltyH(numSeq1[i], numSeq2[j]) + dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
-    // if(!isFinite(H2)) { NC DEL
     G2 = H2 - TEMP_KELVIN*S2;
     if(!isFinite(H2) || (G2 > 0)) {
       H2 = _INFINITY;
@@ -1834,16 +1810,16 @@ LSH(int i, int j, double* EntropyEnthalpy)
       G2 = 1.0;
     }
     T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-    // if(isFinite(H1)) { NC DEL
+
     if(isFinite(H1) && (G1 < 0)) {
       T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-      // if(T1 < T2) { NC DEL
+
       if(T1 < T2  && (G2 < 0)) {
         S1 = S2;
         H1 = H2;
         T1 = T2;
       }
-    // } else { NC DEL
+
     } else if(G2 < 0) {
       S1 = S2;
       H1 = H2;
@@ -1887,22 +1863,20 @@ RSH(int i, int j, double* EntropyEnthalpy) // Ln 1558
   }
   S1 = atPenaltyS(numSeq1[i], numSeq2[j]) + tstack2Entropies[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]][numSeq2[j + 1]];
   H1 = atPenaltyH(numSeq1[i], numSeq2[j]) + tstack2Enthalpies[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]][numSeq2[j + 1]];
-  // if(!isFinite(H1)) { NC DEL
-  G1 = H1 - TEMP_KELVIN*S1;
+  G1 = H1 - (TEMP_KELVIN * S1);
   if(!isFinite(H1) || (G1 > 0)) {
     H1 = _INFINITY;
     S1 = -1.0;
     G1 = 1.0;
   }
 
-  // if(isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]]) && isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) { NC DEL
   if(bpIndx(numSeq1[i+1], numSeq2[j+1]) == 0 && isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]]) && isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) {
     S2 = atPenaltyS(numSeq1[i], numSeq2[j]) + dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +
         dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
     H2 = atPenaltyH(numSeq1[i], numSeq2[j]) + dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +
         dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
-    // if(!isFinite(H2)) { NC DEL
-    G2 = H2 - TEMP_KELVIN*S2;
+
+    G2 = H2 - (TEMP_KELVIN * S2);
     if(!isFinite(H2) || G2>0) {
       H2 = _INFINITY;
       S2 = -1.0;
@@ -1910,16 +1884,16 @@ RSH(int i, int j, double* EntropyEnthalpy) // Ln 1558
     }
 
     T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-    // if(isFinite(H1)) { NC DEL
+
     if(isFinite(H1) && (G1 < 0)) {
       T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-      // if(T1 < T2) { NC DEL
+
       if((T1 < T2) && (G2 < 0)) {
         S1 = S2;
         H1 = H2;
         T1 = T2;
       }
-    // } else {
+
     } else if(G2 < 0){
       S1 = S2;
       H1 = H2;
@@ -1927,11 +1901,9 @@ RSH(int i, int j, double* EntropyEnthalpy) // Ln 1558
     }
   }
 
-  // if(isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]])) { NC DEL
   else if(bpIndx(numSeq1[i+1], numSeq2[j+1]) == 0 && isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]])) {
     S2 = atPenaltyS(numSeq1[i], numSeq2[j]) + dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]];
     H2 = atPenaltyH(numSeq1[i], numSeq2[j]) + dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]];
-    // if(!isFinite(H2)) { NC DEL
     G2 = H2 - TEMP_KELVIN*S2;
     if(!isFinite(H2) || (G2 > 0)) {
       H2 = _INFINITY;
@@ -1939,16 +1911,13 @@ RSH(int i, int j, double* EntropyEnthalpy) // Ln 1558
       G2 = 1.0;
     }
     T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-    // if(isFinite(H1)) { NC DEL
     if(isFinite(H1) && (G1 < 0)) {
       T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-      // if(T1 < T2) { NC DEL
       if(T1 < T2 && (G2 < 0)) {
         S1 = S2;
         H1 = H2;
         T1 = T2;
       }
-    // } else { NC DEL
     } else if (G2 < 0){
       S1 = S2;
       H1 = H2;
@@ -1956,28 +1925,29 @@ RSH(int i, int j, double* EntropyEnthalpy) // Ln 1558
     }
   }
 
-  // if(isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) { NC DEL
   else if (bpIndx(numSeq1[i+1], numSeq2[j+1]) == 0 && isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) {
     S2 = atPenaltyS(numSeq1[i], numSeq2[j]) + dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
     H2 = atPenaltyH(numSeq1[i], numSeq2[j]) + dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
-    // if(!isFinite(H2)) { NC DEL
     G2 = H2 - TEMP_KELVIN*S2;
+
     if (!isFinite(H2) || (G2 > 0)) {
       H2 = _INFINITY;
       S2 = -1.0;
       G2 = 1.0;
     }
+
     T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-    // if(isFinite(H1)) { NC DEL
+
     if (isFinite(H1) && (G1 < 0)) {
+
       T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-      // if(T1 < T2) { NC DEL
+
       if ((T1 < T2) && (G2 < 0)) {
         S1 = S2;
         H1 = H2;
         T1 = T2;
       }
-    // } else { NC DEL
+
     } else if (G2 < 0) {
       S1 = S2;
       H1 = H2;
@@ -2066,7 +2036,7 @@ CBI(int i, int j, double* EntropyEnthalpy, int traceback, int maxLoop)
         EntropyEnthalpy[0] = -1.0;
         EntropyEnthalpy[1] = _INFINITY;
       }
-      // if (isFinite(EnthalpyDPT(ii, jj))) { NC DEL
+
       if (isFinite(EnthalpyDPT(ii, jj)) && isFinite(EnthalpyDPT(i, j))) {
         calc_bulge_internal2(i, j, ii, jj, EntropyEnthalpy, traceback,maxLoop);
         if(isFinite(EntropyEnthalpy[1])) {
@@ -2089,14 +2059,13 @@ static void
 calc_hairpin(int i, int j, double* EntropyEnthalpy, int traceback)
 {
   int loopSize = j - i - 1;
-  // double T1, T2; NC DEL
-  // T1 = T2 = -_INFINITY; NC DEL
   double G1, G2;
   G1 = G2 = -_INFINITY;
   double* SH;
   SH = (double*) safe_malloc(2 * sizeof(double), 0);
   SH[0] = -1.0;
   SH[1] = _INFINITY;
+
   if(loopSize < MIN_HRPN_LOOP) {
     EntropyEnthalpy[0] = -1.0;
     EntropyEnthalpy[1] = _INFINITY;
@@ -2256,7 +2225,6 @@ calc_bulge_internal(int i, int j, int ii, int jj, double* EntropyEnthalpy, int t
         H = _INFINITY;
         S = -1.0;
       }
-      // if(isPositive(H) && isPositive(S) && (!isPositive(EnthalpyDPT(i, j)) || !isPositive(EntropyDPT(i, j)))){ /* if both, S and H are positive */ NC DEL
       if(isPositive(H) && isPositive(S)) {
         H = _INFINITY;
         S = -1.0;
@@ -2281,23 +2249,17 @@ calc_bulge_internal(int i, int j, int ii, int jj, double* EntropyEnthalpy, int t
       H = _INFINITY;
       S = -1.0;
     }
-    // if(isPositive(H) && isPositive(S) && (!isPositive(EnthalpyDPT(ii, jj)) || !isPositive(EntropyDPT(ii, jj)))) { /* if both, S and H are positive */ NC DEL
     if( isPositive(H) && isPositive(S) ) {
       H = _INFINITY;
       S = -1.0;
     }
-    // T1 = (H + dplx_init_H) / ((S + dplx_init_S) + RC);
-    // T2 = (EnthalpyDPT(ii, jj) + dplx_init_H) / (EntropyDPT(ii, jj) + dplx_init_S + RC);
 
-    // if((DBL_EQ(T1,T2) == 2) || traceback==1) {
-    //   if((T1 > T2) || (traceback && T1 >= T2)) {
     RSH(ii,jj,SH);
     G1 = H+SH[1] -TEMP_KELVIN*(S+SH[0]);
     G2 = EnthalpyDPT(ii, jj) + SH[1] - TEMP_KELVIN*(EntropyDPT(ii, jj) + SH[0]);
     if( (G1< G2) || (traceback == 1)) {
         EntropyEnthalpy[0] = S;
         EntropyEnthalpy[1] = H;
-      // } NC DEL
     }
     free(SH);
     return;
@@ -2310,23 +2272,20 @@ calc_bulge_internal(int i, int j, int ii, int jj, double* EntropyEnthalpy, int t
     S = interiorLoopEntropies[loopSize] + tstackEntropies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
           tstackEntropies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]] + (ILAS * abs(loopSize1 - loopSize2));
           S += EntropyDPT(i, j);
+
     if(!isFinite(H)) {
       H = _INFINITY;
       S = -1.0;
     }
-    // if(isPositive(H) && isPositive(S) && (!isPositive(EnthalpyDPT(ii, jj)) || !isPositive(EntropyDPT(ii, jj)))) { /* if both, S and H are positive */ NC DEL
     if(isPositive(H) && isPositive(S)) {
       H = _INFINITY;
       S = -1.0;
     }
-    // T1 = (H + dplx_init_H) / ((S + dplx_init_S) + RC);
-    // T2 = (EnthalpyDPT(ii, jj) + dplx_init_H) / ((EntropyDPT(ii, jj)) + dplx_init_S + RC);
-    // if((T1 > T2) || ((traceback && T1 >= T2) || (traceback==1))) {
-    //   EntropyEnthalpy[0] = S;
-    //   EntropyEnthalpy[1] = H;
+
     RSH(ii,jj,SH);
     G1 = H + SH[1] - TEMP_KELVIN*(S + SH[0]);
     G2 = EnthalpyDPT(ii, jj) + SH[1] - TEMP_KELVIN*(EntropyDPT(ii, jj) + SH[0]);
+
     if( (G1 < G2) || (traceback == 1) ) {
       EntropyEnthalpy[0] = S;
       EntropyEnthalpy[1] = H;
@@ -3035,46 +2994,8 @@ traceback(int i, int j, double RT, int* ps1, int* ps2, int maxLoop, thal_results
   free(SH);
 }
 
-static void
-calcHairpin(int* bp, double mh, double ms, int temponly, double temp, thal_results *o)
-{
-    int i, N = 0;
-    double mg, t;
-    if (!isFinite(ms) || !isFinite(mh)) {
-        if(temponly == 0) {
-            #ifdef DEBUG
-                fputs("No temperature could be calculated\\n",stderr);
-            #endif
-        } else {
-            o->temp = 0.0;
-            o->no_structure = 1;
-        }
-    } else {
-        if(temponly == 0) {
-            for (i = 1; i < len1; ++i) {
-                if(bp[i-1] > 0) N++;
-            }
-        } else {
-            for (i = 1; i < len1; ++i) {
-                if(bp[i-1] > 0) N++;
-            }
-        }
-        t = (mh / (ms + (((N/2)-1) * saltCorrection))) - ABSOLUTE_ZERO;
 
-        if(temponly == 0) {
-            mg = mh - (temp * (ms + (((N/2)-1) * saltCorrection)));
-            ms = ms + (((N/2)-1) * saltCorrection);
-            o->temp = (double) t;
-            o->ds = (double) ms;
-            o->dh = (double) mh;
-            o->dg = (double) mg;
-        } else {
-            o->temp = (double) t;
-        }
-    }
-    return;
-}
-
+/* primer3-py special function */
 static void
 calcDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, double t37, thal_results *o)
 {
@@ -3111,6 +3032,8 @@ calcDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, dou
     return;
 }
 
+
+/* primer3-py special function */
 static void
 drawDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, double t37, thal_results *o)
 {
@@ -3281,6 +3204,50 @@ drawDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, dou
   return;
 }
 
+
+/* primer3-py special function */
+static void
+calcHairpin(int* bp, double mh, double ms, int temponly, double temp, thal_results *o)
+{
+    int i, N = 0;
+    double mg, t;
+    if (!isFinite(ms) || !isFinite(mh)) {
+        if(temponly == 0) {
+            #ifdef DEBUG
+                fputs("No temperature could be calculated\\n",stderr);
+            #endif
+        } else {
+            o->temp = 0.0;
+            o->no_structure = 1;
+        }
+    } else {
+        if(temponly == 0) {
+            for (i = 1; i < len1; ++i) {
+                if(bp[i-1] > 0) N++;
+            }
+        } else {
+            for (i = 1; i < len1; ++i) {
+                if(bp[i-1] > 0) N++;
+            }
+        }
+        t = (mh / (ms + (((N/2)-1) * saltCorrection))) - ABSOLUTE_ZERO;
+
+        if(temponly == 0) {
+            mg = mh - (temp * (ms + (((N/2)-1) * saltCorrection)));
+            ms = ms + (((N/2)-1) * saltCorrection);
+            o->temp = (double) t;
+            o->ds = (double) ms;
+            o->dh = (double) mh;
+            o->dg = (double) mg;
+        } else {
+            o->temp = (double) t;
+        }
+    }
+    return;
+}
+
+
+/* primer3-py special function */
 static void
 drawHairpin(int* bp, double mh, double ms, int temponly, double temp, thal_results *o)
 {

--- a/primer3/src/libprimer3/thal.h
+++ b/primer3/src/libprimer3/thal.h
@@ -191,13 +191,20 @@ void destroy_thal_structures(void);
    to check errno.
 */
 
+/* `print_output` is primer3-py modification argument to simplify conditionally
+* computing structure in calls to `thal` and directing output to `stdout` or to
+* the buffer in the `thal_results` `o->sec_struct` field if it is pre-allocated
+* to not be `NULL`. modified versions of `drawDimer` `drawHairpin` exist to do
+* this work if `print_output == 1` otherwise if `print_output == 0` new
+* functions `calcDimer` and `calcHairpin` are called to compute the `o->temp`
+* `o->ds`, `o->dh`, and `o->dg` fields.  Calls to `thal()` in `libprimer3.c`
+* always use `print_output == 1` for the design path
+*/
 void thal(
       const unsigned char *oligo1,
 	   const unsigned char *oligo2,
 	   const thal_args* a,
       const thal_mode mode,
 	   thal_results* o,
-      const int print_output); /* New arg NC*/
-      // char *ascii_structure); /* New arg NC*/
-
-#endif
+      const int print_output); /* primer3-py modification argument NC */
+#endif /* _THAL_H */

--- a/primer3/src/libprimer3/thal_main.c
+++ b/primer3/src/libprimer3/thal_main.c
@@ -198,7 +198,7 @@ int main(int argc, char** argv)
             exit(-1);
          }
          i++;
-      } else if (!strncmp("-d", argv[i], 2)) { /* dna conc */
+      } else if (!strncmp("-d", argv[i], 3)) { /* primer3-py bug-fix block need to parse 3 characters instead of 2 due to -dv dna conc */
          if(argv[i+1]==NULL) {
 #ifdef DEBUG
             fprintf(stderr, usage, argv[0]);

--- a/tests/test_thermoanalysis.py
+++ b/tests/test_thermoanalysis.py
@@ -90,6 +90,7 @@ class TestLowLevelBindings(unittest.TestCase):
         # self.max_nn_length = 60
 
     def test_calc_tm(self):
+        '''Test basic calc_tm input'''
         for _ in range(100):
             self.randArgs()
             binding_tm = bindings.calc_tm(
@@ -117,6 +118,7 @@ class TestLowLevelBindings(unittest.TestCase):
             self.assertTrue(abs(binding_tm - wrapper_tm) < 0.5)
 
     def test_calc_hairpin(self):
+        '''Test basic hairpin input'''
         for _ in range(1):
             self.randArgs()
             binding_res = bindings.calc_hairpin(
@@ -148,6 +150,7 @@ class TestLowLevelBindings(unittest.TestCase):
             )
 
     def test_calc_homodimer(self):
+        '''Test basic homodimer input'''
         for _ in range(100):
             self.randArgs()
             binding_res = bindings.calc_homodimer(
@@ -181,6 +184,7 @@ class TestLowLevelBindings(unittest.TestCase):
             )
 
     def test_calc_heterodimer(self):
+        '''Test basic heterodimer input'''
         for _ in range(100):
             self.randArgs()
             binding_res = bindings.calc_heterodimer(
@@ -215,7 +219,6 @@ class TestLowLevelBindings(unittest.TestCase):
                 wrapper_res.ascii_structure,
             )
             # Ensure that order of sequences does not matter
-            # Should be fixed as of Primer3 2.3.7 update
             binding_12_res = bindings.calc_heterodimer(
                 seq1=self.seq1,
                 seq2=self.seq2,
@@ -228,8 +231,8 @@ class TestLowLevelBindings(unittest.TestCase):
                 output_structure=True,
             )
             binding_21_res = bindings.calc_heterodimer(
-                seq1=self.seq1,
-                seq2=self.seq2,
+                seq1=self.seq2,
+                seq2=self.seq1,
                 mv_conc=self.mv_conc,
                 dv_conc=self.dv_conc,
                 dntp_conc=self.dntp_conc,
@@ -239,7 +242,75 @@ class TestLowLevelBindings(unittest.TestCase):
             )
             self.assertEqual(int(binding_12_res.tm), int(binding_21_res.tm))
 
+    def test_max_length_heterodimer(self):
+        '''Test longest heterodimer input of 10000 mer per `THAL_MAX_SEQ` '''
+        self.randArgs()
+
+        seq_small = ''.join([
+            random.choice('ATGC') for _ in
+            range(59)  # max size for sequence
+        ])
+        seq_big = ''.join([
+            random.choice('ATGC') for _ in
+            range(10000)  # max size for sequence 2
+        ])
+        binding_res = bindings.calc_heterodimer(
+            seq1=seq_small,
+            seq2=seq_big,
+            mv_conc=self.mv_conc,
+            dv_conc=self.dv_conc,
+            dntp_conc=self.dntp_conc,
+            dna_conc=self.dna_conc,
+            temp_c=self.temp_c,
+            max_loop=self.max_loop,
+            output_structure=True,
+        )
+        wrapper_res = wrappers.calc_heterodimer(
+            seq1=seq_small,
+            seq2=seq_big,
+            mv_conc=self.mv_conc,
+            dv_conc=self.dv_conc,
+            dntp_conc=self.dntp_conc,
+            dna_conc=self.dna_conc,
+            temp_c=self.temp_c,
+            max_loop=self.max_loop,
+        )
+        self.assertEqual(int(binding_res.tm), int(wrapper_res.tm))
+
+        print(binding_res.ascii_structure)
+        print()
+        print(wrapper_res.ascii_structure)
+
+        self.assertEqual(
+            binding_res.ascii_structure,
+            wrapper_res.ascii_structure,
+        )
+        # Ensure that order of sequences does not matter
+        binding_12_res = bindings.calc_heterodimer(
+            seq1=seq_small,
+            seq2=seq_big,
+            mv_conc=self.mv_conc,
+            dv_conc=self.dv_conc,
+            dntp_conc=self.dntp_conc,
+            dna_conc=self.dna_conc,
+            temp_c=self.temp_c,
+            max_loop=self.max_loop,
+            output_structure=True,
+        )
+        binding_21_res = bindings.calc_heterodimer(
+            seq1=seq_big,
+            seq2=seq_small,
+            mv_conc=self.mv_conc,
+            dv_conc=self.dv_conc,
+            dntp_conc=self.dntp_conc,
+            dna_conc=self.dna_conc,
+            temp_c=self.temp_c,
+            max_loop=self.max_loop,
+        )
+        self.assertEqual(int(binding_12_res.tm), int(binding_21_res.tm))
+
     def test_calc_end_stability(self):
+        '''Test calc_end_stability'''
         for _ in range(100):
             self.randArgs()
             binding_res = bindings.calc_end_stability(
@@ -265,6 +336,7 @@ class TestLowLevelBindings(unittest.TestCase):
             self.assertEqual(int(binding_res.tm), int(wrapper_res.tm))
 
     def test_correction_methods(self):
+        '''Test different correction_methods'''
         self.randArgs()
         for sc_method in ['schildkraut', 'santalucia', 'owczarzy']:
             for tm_method in ['breslauer', 'santalucia']:
@@ -300,6 +372,7 @@ class TestLowLevelBindings(unittest.TestCase):
         )
 
     def test_memory_leaks(self):
+        '''Test for memory leaks'''
         sm = _get_mem_usage()
         run_count = 100
         for x in range(run_count):
@@ -335,6 +408,7 @@ class TestLowLevelBindings(unittest.TestCase):
 
 
 def suite():
+    '''Define the test suite'''
     suite = unittest.TestSuite()
     suite.addTest(TestLowLevelBindings())
     return suite


### PR DESCRIPTION
1. `primer3-py` specific comments added/updated for C code.  

2. Updated `strcmp` code for bugfixes due to insufficient parse character count in `amplicontm_main.c`, `oligotm_main.c`, and `primer3_boulder_main.c` related to several parameters in the code.
NOTE: possibly `strlen` should be called to confirm argument lengths prior to comparison.

3. added `test_max_length_heterodimer` and docstrings to `test_thermoanalysis`. Can confirms stack allocation of ~ 41000 works for `duplex_buffer` in `drawDimer` on MacOS 13.2

4.  Fixed order does not matter arguments in the `binding_12_res` /
    `binding_21_res` in `test_calc_heterodimer`.  

5. initialize of `s` pointer to `NULL` in `read_bould_record` to address compiler warning