### PR TITLE
Fix windows build

### DIFF
--- a/primer3/src/libprimer3/libprimer3.c
+++ b/primer3/src/libprimer3/libprimer3.c
@@ -66,6 +66,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* NOTE: primer3-py specific include to enable C only code for hash maps */
 #include "khash.h"
 
+/* Check on which OS we compile */
+#if defined(_WIN32) || defined(WIN32) || defined (__WIN32__) || defined(__CYGWIN__) || defined(__MINGW32__)
+#define OS_WIN
+#endif
+
 #include "dpal.h"
 #include "thal.h"
 #include "oligotm.h"

--- a/primer3/src/libprimer3/thal.c
+++ b/primer3/src/libprimer3/thal.c
@@ -50,6 +50,11 @@
 #include <ieeefp.h>
 #endif
 
+/* Check on which OS we compile */
+#if defined(_WIN32) || defined(WIN32) || defined (__WIN32__) || defined(__CYGWIN__) || defined(__MINGW32__)
+#define OS_WIN
+#endif
+
 #include "thal.h"
 
 /*#define DEBUG*/
@@ -3079,7 +3084,14 @@ drawDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, dou
   }
 
   size_t str_block = (len1 + len2 + 1);
+
+  /* primer3-py | MSVC C99 compiler does not support variable length arrays */
+  #ifdef OS_WIN
+  char* duplex_buffer = (char*)malloc(str_block * 4);
+  #else
   char duplex_buffer[str_block * 4];
+  #endif
+
   char* duplex_0 = duplex_buffer;
   char* duplex_1 = duplex_0 + str_block;
   char* duplex_2 = duplex_1 + str_block;
@@ -3201,6 +3213,10 @@ drawDimer(int* ps1, int* ps2, double temp, double H, double S, int temponly, dou
       duplex_3
     );
   }
+  /* primer3-py | MSVC C99 compiler does not support variable length arrays */
+  #ifdef OS_WIN
+  free(duplex_buffer);
+  #endif
   return;
 }
 
@@ -3292,8 +3308,15 @@ drawHairpin(int* bp, double mh, double ms, int temponly, double temp, thal_resul
       return;
     }
   }
+  /* primer3-py | MSVC C99 compiler does not support variable length arrays */
+  #ifdef OS_WIN
+  /* plain-text output */
+  char* asciiRow = (char*)malloc(len1);
+  #else
   /* plain-text output */
   char asciiRow[len1];
+  #endif
+
   for(i = 1; i < len1+1; ++i) {
     if(bp[i-1] == 0) {
       asciiRow[(i-1)] = '-';
@@ -3324,6 +3347,12 @@ drawHairpin(int* bp, double mh, double ms, int temponly, double temp, thal_resul
   } else {
     printf("\nSTR\t%s\n", oligo1);
   }
+
+  /* primer3-py | MSVC C99 compiler does not support variable length arrays */
+  #ifdef OS_WIN
+  free(asciiRow);
+  #endif
+
   return;
 }
 

--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -1258,7 +1258,7 @@ cdef int pdh_wrap_set_seq_args_globals(
     # NOTE: Masking with PRIMER_MASK_KMERLIST_PATH is parsed in a non standard
     # way in primer3_boulder_main.c therefore we need to do validation twice
     # here and in argdefaults.py
-    if sys.platform != 'windows':
+    IF UNAME_SYSNAME != 'Windows':
         if global_settings_data[0].mask_template:
             global_settings_data[0].lowercase_masking = \
                 global_settings_data[0].mask_template


### PR DESCRIPTION
A small assortment of changes to fix build on windows:

1. `OS_WIN` not defined in `libprimer3.c` or `#include`'d headers (added)
2. MSVC doesn't support variable length C99 arrays (add cond'l malloc for win)
3. Need to set `TESTOPTS=--windows` in `make` invocation on Windows
4. Move `thermoanalysis` conditionals from runtime to preprocessor (no masker support on windows)