### PR TITLE
python 3.8 wheel support

### DIFF
--- a/.github/workflows/build-wheels-pypi.yml
+++ b/.github/workflows/build-wheels-pypi.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-2022]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: checkout
@@ -45,7 +45,7 @@ jobs:
           CIBW_SKIP: "{*-musllinux_*,pp*}"
 
           # Build only on 64-bit architectures.
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_MACOS: "${{ matrix.python-version > 3.8  && 'x86_64 arm64' || 'x86_64' }}"
 
           # NOTE: Commented out to be used with QEMU block above
           # CIBW_ARCHS_LINUX: "x86_64 aarch64"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,6 +9,9 @@
 
 **Primer3-py** is built and tested on MacOS, Linux and Windows 64-bit systems; we do not provide official Windows support. Python versions 3.8 - 3.11 builds are supported.
 
+Wheels are released for CPython versions following the [EOL model](https://devguide.python.org/versions/).
+
+
 ## Installation
 
 If you want to install the latest stable build of **Primer3-py**, you can


### PR DESCRIPTION
Wheel build support for python 3.8 to move towards following the CPython
EOL model. https://devguide.python.org/versions/
    
Added NOTE about it in `quickstart.md`
    
addresses #88 which will close once `1.1.0-staging` merges into `master`
