### PR TITLE
1.1.0 release 

### DIFF
--- a/.github/workflows/build-wheels-pypi.yml
+++ b/.github/workflows/build-wheels-pypi.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-2022]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: checkout
@@ -45,7 +45,7 @@ jobs:
           CIBW_SKIP: "{*-musllinux_*,pp*}"
 
           # Build only on 64-bit architectures.
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_MACOS: "${{ matrix.python-version > 3.8  && 'x86_64 arm64' || 'x86_64' }}"
 
           # NOTE: Commented out to be used with QEMU block above
           # CIBW_ARCHS_LINUX: "x86_64 aarch64"

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 1.1.0 (March 1, 2023)
+ - Added specificity to error non-N IUPAC error for issue #59
+ - Wheel build support for python 3.8 to move towards following the CPython EOL model for issue #88. See https://devguide.python.org/versions/
+
+
 ## Version 1.0.0 (February 11, 2023)
 
 - Migrated `primer3` source to 2.6.1 version, which adds new arguments for melting temperature code

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,6 +9,9 @@
 
 **Primer3-py** is built and tested on MacOS, Linux and Windows 64-bit systems; we do not provide official Windows support. Python versions 3.8 - 3.11 builds are supported.
 
+Wheels are released for CPython versions following the [EOL model](https://devguide.python.org/versions/).
+
+
 ## Installation
 
 If you want to install the latest stable build of **Primer3-py**, you can

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -26,7 +26,7 @@ import os
 from typing import List
 
 # Per PEP-440 https://peps.python.org/pep-0440/#public-version-identifiers
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
     'Copyright 2014-2023, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'

--- a/primer3/src/libprimer3/libprimer3.c
+++ b/primer3/src/libprimer3/libprimer3.c
@@ -7579,12 +7579,17 @@ _pr_data_control(const p3_global_settings *pa,
   }
 
   if ((offending_char = dna_to_upper(sa->trimmed_seq, 0))) {
+    char err_msg[64];
+    snprintf(
+      err_msg,
+      64,
+      "Rejecting invalid sequence character (only ACGTN allowed): %c",
+      offending_char
+    );
     if (pa->liberal_base) {
-      pr_append_new_chunk(warning,
-                          "Unrecognized base in input sequence");
+      pr_append_new_chunk(warning, err_msg);
     } else {
-      pr_append_new_chunk(nonfatal_err,
-                          "Unrecognized base in input sequence");
+      pr_append_new_chunk(nonfatal_err, err_msg);
       return 1;
     }
   }


### PR DESCRIPTION
 - Added specificity to error non-N IUPAC error for issue #59
 - Wheel build support for python 3.8 to move towards following the CPython EOL model for issue #88. See https://devguide.python.org/versions/