### PR TITLE
`p3helpers.pyx` houses new sequence and design helper functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ primer3_masker
 
 # cython artifacts
 primer3/thermoanalysis.c
+primer3/p3helpers.c
 
 # test artifacts
 primer3/src/libprimer3/long_seq_tm_test.dSYM/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README.md LICENSE CHANGES AUTHORS setup.py
 include .pre-commit-config.yaml dev-requirements.txt setup.cfg
-include primer3/*.pxd primer3/*.pyx
+include primer3/*.pxd primer3/*.pyx primer3/*.h
 include primer3/src/libprimer3/*.h primer3/src/libprimer3/*.c
 include primer3/src/libprimer3/klib/khash.h
 include primer3/src/libprimer3/klib/README.md

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -8,4 +8,5 @@ and classes contained within **primer3-py**.
 
 bindings
 thermoanalysis
+p3helpers
 ```

--- a/docs/api/p3helpers.md
+++ b/docs/api/p3helpers.md
@@ -1,0 +1,5 @@
+```{eval-rst}
+.. automodule:: primer3.p3helpers
+   :members:
+   :inherited-members:
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,105 +27,8 @@ If your Python version and platform fall outside this such as Linux `aarch64` it
 
 ## Thermodynamic analysis
 
-The thermodynamic {py:mod}`bindings` include support for **Tm, homodimer, heterodimer,
+The thermodynamic {py:mod}`primer3.bindings` include support for **Tm, homodimer, heterodimer,
 hairpin,** and **3' end stability calculations**:
-
-```{eval-rst}
-.. py:function:: calc_tm(seq, mv_conc=50, dv_conc=0, dntp_conc=0.8, \
-                        dna_conc=50, dmso_conc=0.0, dmso_fact=0.6, \
-                        formamide_conc=0.8, annealing_temp_c=-10.0, \
-                        max_nn_length=60, tm_method='santalucia', \
-                        salt_corrections_method='santalucia')
-
-    Calculates the melting temperature of a DNA sequence, ``seq``. Returns the
-    melting temperature (C) as a float::
-
-        >>> primer3.calc_tm('GTAAAACGACGGCCAGT')
-        49.16808228911765
-
-    Note that NN thermodynamics will be used to calculate the Tm of sequences
-    up to 60 bp in length, after which point the following formula will be
-    used::
-
-        Tm = 81.5 + 16.6(log10([mv_conc])) + 0.41(%GC) - 600/length
-
-```
-
-```{eval-rst}
-.. py:function:: calc_hairpin(seq, mv_conc=50.0, dv_conc=0.0, dntp_conc=0.8, \
-                             dna_conc=50.0, temp_c=37, max_loop=30, \
-                             output_structure=False)
-
-    Calculates the hairpin formation thermodynamics of a DNA sequence, ``seq``.
-    Returns a :class:`ThermoResult` object that provides access to the
-    thermodynamic characteristics of the result::
-
-        >>> res = primer3.calc_hairpin('CCCCCATCCGATCAGGGGG')
-        >>> print(res)
-        ThermoResult(structure_found=True, tm=34.15, dg=337.09, dh=-36300.00,
-                     ds=-118.13, msg=)
-        >>> print(res.tm)
-        34.14640571476207
-        >>> print('%f, %f, %f' % (res.dg, res.dh, res.ds))
-        337.086509, -36300.000000, -118.126992
-
-    **Note that at least one of the two sequences must by <60 bp in length.**
-    This is a cap imposed by Primer3 as the longest reasonable sequence length
-    for which a two-state NN model produces reliable results (see
-    ``primer3/src/libnano/thal.h:59``).
-
-```
-
-```{eval-rst}
-.. py:function:: calc_homodimer(seq, mv_conc=50.0, dv_conc=0.0, dntp_conc=0.8, \
-                               dna_conc=50.0, temp_c=37, max_loop=30, \
-                               output_structure=False)
-
-    Calculates the homodimer formation thermodynamics of a DNA sequence,
-    ``seq``. Returns a :class:`ThermoResult` object that provides access to the
-    thermodynamic characteristics of the result (see :py:func:`calc_hairpin`
-    doc for more information).
-
-    **Note that the maximum length of ``seq`` is 60 bp.** This is a cap imposed
-    by Primer3 as the longest reasonable sequence length for which
-    a two-state NN model produces reliable results (see
-    ``primer3/src/libprimer3/thal.h:59``).
-
-```
-
-```{eval-rst}
-.. py:function:: calc_heterodimer(seq1, seq2, mv_conc=50.0, dv_conc=0.0, \
-                                 dntp_conc=0.8, dna_conc=50.0, temp_c=37, \
-                                 max_loop=30, output_structure=False)
-
-    Calculates the heterodimerization thermodynamics of two DNA sequences,
-    ``seq1`` and ``seq2``. Returns a :class:`ThermoResult` object that provides
-    access to the thermodynamic characteristics of the result
-    (see :py:func:`calc_hairpin` doc for more information).
-
-    **Note that at least one of the two sequences must by <60 bp in length.**
-    This is a cap imposed by Primer3 as the longest reasonable sequence length
-    for which a two-state NN model produces reliable results (see
-    ``primer3/src/libprimer3/thal.h:59``).
-
-```
-
-```{eval-rst}
-.. py:function:: calc_end_stability(seq1, seq2, mv_conc=50.0, dv_conc=0.0, \
-                                  dntp_conc=0.8, dna_conc=50.0, temp_c=37, \
-                                  max_loop=30)
-
-    Calculates the 3' end stability of DNA sequence ``seq1`` against DNA
-    sequence ``seq2``. Returns a :class:`ThermoResult` object that provides
-    access to the thermodynamic characteristics of the result
-    (see :py:func:`calc_hairpin` doc for more information).
-
-    **Note that at least one of the two sequences must by <60 bp in length.**
-    This is a cap imposed by Primer3 as the longest reasonable sequence length
-    for which a two-state NN model produces reliable results (see
-    ``primer3/src/libprimer3/thal.h:59``).
-
-```
 
 All of these low-level thermodynamic functions share a set of keyword arguments
 used to define the parameters of the respective calculation:
@@ -165,6 +68,10 @@ used to define the parameters of the respective calculation:
 
 ```
 
+For finer grain control of analysis, use {py:mod}`primer3.thermoanalysis`.
+NOTE. camelCase methods are deprecated.  Please write all new code with
+{py:class}`primer3.thermoanalysis.ThermoAnalysis` snake case methods
+
 ## Primer design
 
 **Primer3-py** includes bindings for the Primer3 primer design pipeline. The
@@ -198,14 +105,10 @@ Primer3-py Python input:      [[75,100],[100,125],[125,150]]
 ### Workflow
 
 The easiest way to run the primer design pipeline is with
-{py:func}`design_primers`. Notice that Primer3 parameters prefixed with
+{py:func}`primer3.bindings.design_primers`. Notice that Primer3 parameters prefixed with
 "SEQUENCE\_" are provided in a separate dictionary from those prefixed with
 "PRIMER\_". For more advanced / modular approaches, see the {doc}`api/bindings`
 documentation.
-
-```{eval-rst}
-.. autofunction:: primer3.bindings.design_primers
-```
 
 Example usage:
 

--- a/primer3/bindings.py
+++ b/primer3/bindings.py
@@ -542,6 +542,7 @@ def design_primers(
     Returns:
         A dictionary of Primer3 results (should be identical to the expected
         BoulderIO output from ``primer3_main``)
+
     '''
     return THERMO_ANALYSIS.run_design(
         global_args=global_args,

--- a/primer3/p3helpers.h
+++ b/primer3/p3helpers.h
@@ -1,0 +1,64 @@
+/*
+* Copyright (C) 2023. Ben Pruitt & Nick Conway;
+* See LICENSE for full GPLv2 license.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program; if not, write to the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* primer3.p3helpers.h
+* Helper functions C definitions for p3helpers.pyx
+*/
+
+#ifndef __P3PY_P3HELPERS_H
+#define __P3PY_P3HELPERS_H
+
+const char COMP_BASE_LUT[128] = {
+    '?', '?', '?', '?', '?', '?', '?', '?', // 7
+    '?', '?', '?', '?', '?', '?', '?', '?', // 15
+    '?', '?', '?', '?', '?', '?', '?', '?', // 23
+    '?', '?', '?', '?', '?', '?', '?', '?', // 31
+    '?', '?', '?', '?', '?', '?', '?', '?', // 39
+    '?', '?', '?', '?', '?', '?', '?', '?', // 47
+    '?', '?', '?', '?', '?', '?', '?', '?', // 55
+    '?', '?', '?', '?', '?', '?', '?', '?', // 63
+    '?', 'T', 'V', 'G', 'H', '?', '?', 'C', // 71
+    'D', '?', '?', 'M', '?', 'K', 'N', '?', // 79
+    '?', '?', 'Y', 'S', 'A', '?', 'B', 'W', // 87
+    '?', 'R', '?', '?', '?', '?', '?', '?', // 95
+    '?', 't', 'v', 'g', 'h', '?', '?', 'c', // 103
+    'd', '?', '?', 'm', '?', 'k', 'n', '?', // 111
+    '?', '?', 'y', 's', 'a', '?', 'b', 'w', // 119
+    '?', 'r', '?', '?', '?', '?', '?', '?'  // 127
+};
+
+const char SANITIZE_LUT[128] = {
+ '?', '?', '?', '?', '?', '?', '?', '?', // 7
+ '?', '?', '?', '?', '?', '?', '?', '?', // 15
+ '?', '?', '?', '?', '?', '?', '?', '?', // 23
+ '?', '?', '?', '?', '?', '?', '?', '?', // 31
+ '?', '?', '?', '?', '?', '?', '?', '?', // 39
+ '?', '?', '?', '?', '?', '?', '?', '?', // 47
+ '?', '?', '?', '?', '?', '?', '?', '?', // 55
+ '?', '?', '?', '?', '?', '?', '?', '?', // 63
+ '?', 'A', 'N', 'C', 'N', '?', '?', 'G', // 71
+ 'N', '?', '?', 'N', '?', 'N', 'N', '?', // 79
+ '?', '?', 'N', 'N', 'T', 'N', 'N', 'N', // 87
+ '?', 'N', '?', '?', '?', '?', '?', '?', // 95
+ '?', 'a', 'n', 'c', 'n', '?', '?', 'g', // 103
+ 'n', '?', '?', 'n', '?', 'n', 'n', '?', // 111
+ '?', '?', 'n', 'n', 't', 'n', 'n', 'n', // 119
+ '?', 'n', '?', '?', '?', '?', '?', '?'  // 127
+};
+
+#endif

--- a/primer3/p3helpers.pyx
+++ b/primer3/p3helpers.pyx
@@ -1,0 +1,282 @@
+# cython: language_level=3
+# Copyright (C) 2023. Ben Pruitt & Nick Conway;
+# See LICENSE for full GPLv2 license.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+'''
+primer3.p3helpers
+~~~~~~~~~~~~~~~~~~~~~~
+
+Contains Cython functions and classes that aid primer design
+
+'''
+from cpython.mem cimport (
+    PyMem_Free,
+    PyMem_Malloc,
+)
+from libc.string cimport memcpy
+
+
+cdef extern from "p3helpers.h":
+    const char COMP_BASE_LUT[128]
+    const char SANITIZE_LUT[128]
+
+
+cdef:
+    char INVALID_BASE = 63 # '?' character
+
+
+cdef inline void copy_c_char_buffer(
+    char*   in_buf,
+    char*   out_buf,
+    int     str_length,
+):
+    '''Copy string to buffer.  Unsafe
+
+    Args:
+        in_buf: input buffer
+        out_buf: output buffer. Assume buffer size is equal to or greater than
+            in_buf size.
+        str_length: known number of bytes to copy
+    '''
+    memcpy(out_buf, in_buf, <size_t> str_length + 1)
+
+
+cdef int ss_rev_comp_seq(char* seq, Py_ssize_t length) nogil:
+    '''Reverse complement sequence C string
+
+    Args:
+        seq: sequence to sanitize
+        length: length of sequence
+
+    Returns:
+        0 on success, 1 on error (Invalid base)
+    '''
+    cdef:
+        char        temp
+        char*       end_ptr = NULL
+
+    end_ptr = seq + (length - 1)
+
+    while end_ptr > seq:
+        temp = end_ptr[0]
+        end_ptr[0] = COMP_BASE_LUT[<unsigned char> seq[0]]
+        if end_ptr[0] == INVALID_BASE:
+            return 1
+        end_ptr -= 1
+        seq[0] = COMP_BASE_LUT[<unsigned char> temp]
+        if seq[0] == INVALID_BASE:
+            return 1
+        seq += 1
+
+
+    if length % 2:
+        seq[0] = COMP_BASE_LUT[<unsigned char> seq[0]]
+
+    return 0
+
+
+cdef int ss_sanitize_seq(
+    char* seq,
+    Py_ssize_t length,
+) nogil:
+    '''Sanitize sequence C string IUPAC non-{A,C,G,T,a,c,g,t} bases with {N, n}
+
+    Args:
+        seq: sequence to sanitize
+        length: length of sequence
+
+    Returns:
+        0 on success, 1 on error (Invalid base)
+    '''
+    cdef:
+        char*       end_ptr = seq + length
+
+    while seq < end_ptr:
+        seq[0] = SANITIZE_LUT[<unsigned char> seq[0]]
+        if seq[0] == INVALID_BASE:
+            return 1
+        seq += 1
+    return 0
+
+
+def reverse_complement(
+        seq: str,
+        bint do_sanitize = False,
+) -> str:
+    '''Compute reverse complement of the python string sequence
+
+    Args:
+        seq: sequence string
+        do_sanitize: If True, convert non-IUPAC characters to N's
+
+    Returns:
+        Reverse complement of sequence string
+
+    Raises:
+        ValueError: Invalid base in sequence
+    '''
+    cdef:
+        char* seq_c = NULL
+        Py_ssize_t seq_len = len(seq)
+        int check = 0
+
+    seq_b = seq.encode('utf8')
+    # convert to C str
+    seq_c = seq_b
+
+    check = ss_rev_comp_seq(seq_c, seq_len)
+    if check:
+        raise ValueError(f'Invalid base in sequence {seq}')
+    if do_sanitize:
+        check = ss_sanitize_seq(seq_c, seq_len)
+        if check:
+            raise ValueError(f'Invalid base in sequence {seq}')
+    seq_b = seq_c
+
+    return seq_b.decode('utf8')
+
+
+def reverse_complement_b(
+        seq: bytes,
+        bint do_sanitize = False,
+) -> bytes:
+    '''Compute reverse complement of the bytes sequence
+
+    Args:
+        seq: sequence in bytes
+        do_sanitize: If True, convert non-IUPAC characters to N's
+
+    Returns:
+        Reverse complement of sequence in bytes
+
+    Raises:
+        ValueError: Invalid base in sequence
+        OSError: ``malloc`` failure
+    '''
+    cdef:
+        char* seq_c = NULL
+        Py_ssize_t seq_len = len(seq)
+        char* seq_operate_c = NULL
+        bytes seq_out
+        int check = 0
+
+    seq_operate_c = <char *> PyMem_Malloc(seq_len * sizeof(char))
+    if seq_operate_c == NULL:
+        raise OSError('malloc failure')
+
+    # convert to C str
+    seq_c = seq
+
+    # MUST COPY as python does not mutate bytes
+    copy_c_char_buffer(seq_c, seq_operate_c, seq_len + 1)
+
+    check = ss_rev_comp_seq(seq_operate_c, seq_len)
+    if check:
+        raise ValueError(f'Invalid base in sequence {seq}')
+    if do_sanitize:
+        check = ss_sanitize_seq(seq_operate_c, seq_len)
+        if check:
+            PyMem_Free(seq_operate_c)
+            seq_operate_c = NULL
+            raise ValueError(f'Invalid base in sequence {seq}')
+    seq_out = seq_operate_c
+    PyMem_Free(seq_operate_c)
+    seq_operate_c = NULL
+    return seq_out
+
+
+def sanitize_sequence(seq: str) -> str:
+    '''Sanitize sequence with non-standard bases with `N`s
+    IUPAC {R,Y,M,K,S,W,H,D,B,V,r,y,m,k,s,w,h,d,b,v}
+
+    IUPAC non-{A,C,G,T,a,c,g,t} bases become {N, n}
+
+    NOTE: Consider keeping a copy of original ``seq`` argument for record
+    keeping
+
+    Args:
+        seq: sequence to sanitize nonstandard with `N`s or `n`s
+
+    Returns:
+        sanitized version of ``seq``
+
+    Raises:
+        ValueError: Invalid base in sequence
+    '''
+    cdef:
+        char* seq_c = NULL
+        Py_ssize_t seq_len = len(seq)
+        int check = 0
+
+    seq_b = seq.encode('utf8')
+    # convert to C str
+    seq_c = seq_b
+
+    check = ss_sanitize_seq(seq_c, seq_len)
+    if check:
+        raise ValueError(f'Invalid base in equence {seq}')
+    seq_b = seq_c
+
+    return seq_b.decode('utf8')
+
+
+def sanitize_sequence_b(
+        seq: bytes,
+) -> bytes:
+    '''Sanitize bytes sequence with non-standard bases with `N`s
+    IUPAC {R,Y,M,K,S,W,H,D,B,V,r,y,m,k,s,w,h,d,b,v}
+
+    IUPAC non-{A,C,G,T,a,c,g,t} bases become {N, n}
+
+    NOTE: Consider keeping a copy of original ``seq`` argument for record
+    keeping
+
+    Args:
+        seq: sequence to sanitize nonstandard with `N`s or `n`s
+
+    Returns:
+        sanitized version of ``seq``
+
+    Raises:
+        ValueError: Invalid base in sequence
+        OSError: ``malloc`` failure
+    '''
+    cdef:
+        char* seq_c = NULL
+        Py_ssize_t seq_len = len(seq)
+        char* seq_operate_c = NULL
+        bytes seq_out
+        int check = 0
+
+    seq_operate_c = <char *> PyMem_Malloc(seq_len * sizeof(char))
+    if seq_operate_c == NULL:
+        raise OSError('malloc failure')
+
+    # convert to C str
+    seq_c = seq
+
+    # MUST COPY as python does not mutate bytes
+    copy_c_char_buffer(seq_c, seq_operate_c, seq_len + 1)
+
+    check = ss_sanitize_seq(seq_operate_c, seq_len)
+    if check:
+        PyMem_Free(seq_operate_c)
+        seq_operate_c = NULL
+        raise ValueError(f'Invalid base in equence {seq}')
+    seq_out = seq_operate_c
+    PyMem_Free(seq_operate_c)
+    seq_operate_c = NULL
+    return seq_out

--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -1,5 +1,6 @@
 # cython: language_level=3
 # Copyright (C) 2014-2020. Ben Pruitt & Nick Conway; Wyss Institute
+# Copyright (C) 2023 Ben Pruitt & Nick Conway;
 # See LICENSE for full GPLv2 license.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -104,6 +105,7 @@ cdef unsigned char[:] _chars(s):
         return o
     return memoryview(s)
 
+
 cdef inline bytes _bytes(s):
     # Note that this check gets optimized out by the C compiler and is
     # recommended over the IF/ELSE Cython compile-time directives
@@ -113,6 +115,7 @@ cdef inline bytes _bytes(s):
         return (<str>s).encode('utf8')
     else:
         return s
+
 
 # ~~~~~~~~~ Load base thermodynamic parameters into memory from file ~~~~~~~~ #
 def load_thermo_params():
@@ -171,6 +174,7 @@ cdef class ThermoResult:
     to expose tm, dg, dh, and ds values that result from a :meth:`calc_hairpin`,
     :meth:`calc_homodimer`, :meth:`calc_heterodimer`, or
     :meth:`calc_end_stability` calculation.
+
     '''
 
     def __cinit__(self):
@@ -218,6 +222,7 @@ cdef class ThermoResult:
                 'STR\t      ACG CTAC C    CGA ACG                           ',
                 'STR\tAACCTT   T    T TTAT   G   TAGGCGAGCCACCAGCGGCATAGTAA-',
             ]
+
         '''
         if self.ascii_structure:
             return self.ascii_structure.strip('\n').split('\n')
@@ -231,6 +236,7 @@ cdef class ThermoResult:
 
         Raises:
             :class:`RuntimeError`: Message of internal C error
+
         '''
         if len(self.thalres.msg):
             raise RuntimeError(self.thalres.msg)
@@ -256,6 +262,7 @@ cdef class ThermoResult:
 
         Returns:
             dictionary form of the :class:`ThermoResult`
+
         '''
         return {
             'structure_found': self.structure_found,
@@ -286,6 +293,7 @@ def _conditional_get_enum_int(
     Raises:
         :class:`ValueError`: arg_value missing in the map ``dict_obj``
         :class:`TypeError`: invalid type for the key
+
     '''
     if isinstance(arg_value, (int, long)):
         return arg_value
@@ -396,6 +404,7 @@ cdef class _ThermoAnalysis:
                     'santalucia': 1,
                     'owczarzy': 2
                 }
+
             '''
         self.thalargs.mv = mv_conc
         self.thalargs.dv = dv_conc
@@ -502,6 +511,7 @@ cdef class _ThermoAnalysis:
         '''Method used to calculate melting temperatures. May be provided as
         a string (see :attr:`tm_methods_dict`) or the respective integer
         representation.
+
         '''
         return self._tm_methods_int_dict[self._tm_method]
 
@@ -519,6 +529,7 @@ cdef class _ThermoAnalysis:
         calculations. May be provided as a string (see
         :attr:`salt_correction_methods_dict`) or the respective integer
         representation.
+
         '''
         return self._salt_correction_method
 
@@ -1224,6 +1235,7 @@ cdef int pdh_wrap_set_seq_args_globals(
 
     Raises:
         ValueError: Error parsing the data
+
     '''
     cdef:
         # Setup the input data structures handlers
@@ -1344,6 +1356,7 @@ cdef seq_lib* pdh_create_seq_lib(object seq_dict) except NULL:
         OSError: Could not allocate memory for seq_lib
         TypeError: Cannot add seq name with non-Unicode/Bytes type to seq_lib
         OSError: primer3 internal error
+
     '''
 
     cdef:
@@ -1403,6 +1416,7 @@ cdef object pdh_design_output_to_dict(
 
     Raises:
         OSError: memory issue
+
     '''
     cdef:
         # The pointers to warning tag

--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,7 @@ PACKAGE_FPS = (
     LIBPRIMER3_C_EXTRA_FPS +
     LIBPRIMER3_H_FPS +
     KLIB_H_FPS +
+    ['p3helpers.pyx', 'p3helpers.h'] +
     ['thermoanalysis.pxd', 'thermoanalysis.pyx']
 )
 
@@ -278,6 +279,12 @@ else:
     ]
 
 cython_extensions = [
+    Extension(
+        'primer3.p3helpers',
+        sources=[pjoin('primer3', 'p3helpers.pyx')],
+        include_dirs=[MODULE_PATH],
+        extra_compile_args=EXTRA_COMPILE_ARGS,
+    ),
     Extension(
         'primer3.thermoanalysis',
         sources=[pjoin('primer3', 'thermoanalysis.pyx')] + LIBPRIMER3_C_FPS,

--- a/tests/test_p3helpers.py
+++ b/tests/test_p3helpers.py
@@ -1,0 +1,115 @@
+# Copyright (C) 2014-2020. Ben Pruitt & Nick Conway; Wyss Institute
+# See LICENSE for full GPLv2 license.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+'''
+tests.test_p3helpers
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unit tests for the primer3-py p3helpers.
+
+'''
+
+import unittest
+
+from primer3 import p3helpers  # type: ignore
+
+
+class TestP3Helpers(unittest.TestCase):
+
+    def test_sanitize_sequence(self):
+        # 1. Test upper case
+        seq = 'ACGTRYMKSWHDBV'
+        out_seq = p3helpers.sanitize_sequence(seq)
+        self.assertEqual(out_seq, 'ACGTNNNNNNNNNN')
+
+        # 2. Test lower case
+        seq = 'acgtrymkswhdbv'
+        out_seq = p3helpers.sanitize_sequence(seq)
+        self.assertEqual(out_seq, 'acgtnnnnnnnnnn')
+
+        # 3. Test bytes upper case
+        seq = b'ACGTRYMKSWHDBV'
+        out_seq = p3helpers.sanitize_sequence_b(seq)
+        self.assertEqual(out_seq, b'ACGTNNNNNNNNNN')
+
+        # 4. Test bytes lower case
+        seq = b'acgtrymkswhdbv'
+        out_seq = p3helpers.sanitize_sequence_b(seq)
+        self.assertEqual(out_seq, b'acgtnnnnnnnnnn')
+
+        # 5. Test ValueError for bad base
+        self.assertRaises(
+            ValueError,
+            p3helpers.sanitize_sequence,
+            'ZACGT',
+        )
+
+    def test_reverse_complement(self):
+        # 1. Test upper case no sanitize
+        seq = 'ACGTRYMKSWHDBV'
+        out_seq = p3helpers.reverse_complement(seq, do_sanitize=False)
+        self.assertEqual(out_seq, 'BVHDWSMKRYACGT')
+
+        # 2. Test upper case sanitize
+        out_seq = p3helpers.reverse_complement(seq, do_sanitize=True)
+        self.assertEqual(out_seq, 'NNNNNNNNNNACGT')
+
+        # 3. Test lower case no sanitize
+        seq = 'acgtrymkswhdbv'
+        out_seq = p3helpers.reverse_complement(seq, do_sanitize=False)
+        self.assertEqual(out_seq, 'bvhdwsmkryacgt')
+
+        # 4. Test lower case sanitize
+        out_seq = p3helpers.reverse_complement(seq, do_sanitize=True)
+        self.assertEqual(out_seq, 'nnnnnnnnnnacgt')
+
+        # 5. Test bytes upper case no sanitize
+        seq = b'ACGTRYMKSWHDBV'
+        out_seq = p3helpers.reverse_complement_b(seq, do_sanitize=False)
+        self.assertEqual(out_seq, b'BVHDWSMKRYACGT')
+
+        # 5. Test bytes upper case sanitize
+        out_seq = p3helpers.reverse_complement_b(seq, do_sanitize=True)
+        self.assertEqual(out_seq, b'NNNNNNNNNNACGT')
+
+        # 6. Test bytes lower case no sanitize
+        seq = b'acgtrymkswhdbv'
+        out_seq = p3helpers.reverse_complement_b(seq, do_sanitize=False)
+        self.assertEqual(out_seq, b'bvhdwsmkryacgt')
+
+        # 7. Test bytes lower case sanitize
+        out_seq = p3helpers.reverse_complement_b(seq, do_sanitize=True)
+        self.assertEqual(out_seq, b'nnnnnnnnnnacgt')
+
+        # 8. Test ValueError for bad base
+        self.assertRaises(
+            ValueError,
+            p3helpers.reverse_complement,
+            'ZACGT',
+        )
+
+
+def suite():
+    '''Define the test suite'''
+    suite = unittest.TestSuite()
+    suite.addTest(TestP3Helpers())
+    return suite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    test_suite = suite()
+    runner.run(test_suite)


### PR DESCRIPTION
Sequence sanitization of IUPAC non-{A,C,G,T,a,c,g,t} bases become {N, n} and also reverse complement added.  Separate methods exist for byte strings and unicode strings with error handling.

The intent is `p3helpers.pyx` will be a separate module for helper functions for primer design that exist outside of the separate`libnano/libnano` package prior to its update and release.

`docs/` updated to support `p3helpers.pyx` and remove duplicates in the documentation.

This PR will help address issue #57 