### PR TITLE
thread-safe `thal.c` code and `nogil` updates for `ThermoAnalysis`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 1.2.0 ()
+
+- Threadsafe changes made to `thal.c` resulting in new  `thalflex.c` and `thalflex.h` and `thalflexsignatures.h`.
+- `test_threadsafe.py` add and `nogil` instituted for calls to `thal()` and `seqtm()` added `run_design` and `calc_heterodimer` threadsafe tests
+- `ThermoAnalysis` class no longer needs to be a `Singleton` so this was removed as a parent class
+- `p3helpers.pyx` houses new sequence and design helper functions
+- `setup.py` `package_data` and `MANIFEST.in` to assist with future builds from tar.gz (`conda`)
+
 ## Version 1.1.0 (March 1, 2023)
  - Added specificity to error non-N IUPAC error for issue #59
  - Wheel build support for python 3.8 to move towards following the CPython EOL model for issue #88. See https://devguide.python.org/versions/

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -26,7 +26,7 @@ import os
 from typing import List
 
 # Per PEP-440 https://peps.python.org/pep-0440/#public-version-identifiers
-__version__ = '1.1.0'
+__version__ = '1.2.0a1'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
     'Copyright 2014-2023, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'

--- a/primer3/bindings.py
+++ b/primer3/bindings.py
@@ -40,8 +40,10 @@ from typing import (
     Union,
 )
 
-from primer3 import thermoanalysis  # type: ignore
-from primer3 import argdefaults
+from primer3 import (  # type: ignore
+    argdefaults,
+    thermoanalysis,
+)
 
 DEFAULT_P3_ARGS = argdefaults.Primer3PyArguments()
 THERMO_ANALYSIS = thermoanalysis.ThermoAnalysis()

--- a/primer3/src/libprimer3/thal.h
+++ b/primer3/src/libprimer3/thal.h
@@ -175,13 +175,13 @@ void set_thal_oligo_default_args(thal_args *a);
     exit(-1);
   }
 #endif
-int  thal_set_null_parameters(thal_parameters *a);
+int thal_set_null_parameters(thal_parameters *a);
 
-int  thal_load_parameters(const char *path, thal_parameters *a, thal_results* o);
+int thal_load_parameters(const char *path, thal_parameters *a, thal_results* o);
 
-int  thal_free_parameters(thal_parameters *a);
+int thal_free_parameters(thal_parameters *a);
 
-int  get_thermodynamic_values(const thal_parameters *tp, thal_results *o);
+int get_thermodynamic_values(const thal_parameters *tp, thal_results *o);
 
 void destroy_thal_structures(void);
 

--- a/primer3/src/libprimer3/thalflex.h
+++ b/primer3/src/libprimer3/thalflex.h
@@ -1,0 +1,961 @@
+/* libprimer3/thalflex.h
+
+ Copyright (c) 1996,1997,1998,1999,2000,2001,2004,2006,2007,2009,2010,
+               2011,2012,2016
+ Whitehead Institute for Biomedical Research, Steve Rozen
+ (http://purl.com/STEVEROZEN/), and Helen Skaletsky
+ All rights reserved.
+
+       This file is part of primer3 software suite.
+
+       This software suite is is free software;
+       you can redistribute it and/or modify it under the terms
+       of the GNU General Public License as published by the Free
+       Software Foundation; either version 2 of the License, or (at
+       your option) any later version.
+
+       This software is distributed in the hope that it will be useful,
+       but WITHOUT ANY WARRANTY; without even the implied warranty of
+       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+       GNU General Public License for more details.
+
+       You should have received a copy of the GNU General Public License
+       along with this software (file gpl-2.0.txt in the source
+       distribution); if not, write to the Free Software
+       Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON A THEORY
+ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Modifications to thal.c code to create thalflex.h.
+Copyright (C) 2023. Ben Pruitt & Nick Conway;
+
+See thalflex.c for more info on thalflex.h
+*/
+#ifndef _P3PY_THALFLEX_H
+#define _P3PY_THALFLEX_H
+
+typedef struct thalflex_packet_t {
+    double* send5;
+    double* hend5;
+    double* entropyDPT;
+    double* enthalpyDPT;
+    unsigned char* numSeq1;
+    int len1;
+    unsigned char* numSeq2;
+    int len2;
+    int len3;
+    double dplx_init_S;
+    double dplx_init_H;
+    double RC;
+} thalflex_packet_t;
+
+
+thalflex_packet_t make_thalflex_packet(
+    double* send5,
+    double* hend5,
+    double* entropyDPT,
+    double* enthalpyDPT,
+    unsigned char* numSeq1,
+    int len1,
+    unsigned char* numSeq2,
+    int len2,
+    int len3,
+    double dplx_init_S,
+    double dplx_init_H,
+    double RC
+) {
+  thalflex_packet_t tfpacket = {
+      .send5 = send5,
+      .hend5 = hend5,
+      .entropyDPT = entropyDPT,
+      .enthalpyDPT = enthalpyDPT,
+      .numSeq1 = numSeq1,
+      .len1 = len1,
+      .numSeq2 = numSeq2,
+      .len2 = len2,
+      .len3 = len3,
+      .dplx_init_S = dplx_init_S,
+      .dplx_init_H = dplx_init_H,
+      .RC = RC
+  };
+  return tfpacket;
+}
+
+/* Handle unpacking boiler plate */
+#define UNPACK_TFPACKET_CBI()                   \
+  double* entropyDPT = tf_packet->entropyDPT;   \
+  double* enthalpyDPT = tf_packet->enthalpyDPT; \
+  unsigned char* numSeq1 = tf_packet->numSeq1;  \
+  int len1 = tf_packet->len1;                   \
+  unsigned char* numSeq2 = tf_packet->numSeq2;  \
+  int len2 = tf_packet->len2;                   \
+  int len3 = tf_packet->len3;                   \
+  double dplx_init_S = tf_packet->dplx_init_S;  \
+  double dplx_init_H = tf_packet->dplx_init_H;  \
+  double RC = tf_packet->RC;
+
+
+#define UNPACK_TFPACKET_ALL()       \
+  double* send5 = tf_packet->send5; \
+  double* hend5 = tf_packet->hend5; \
+  UNPACK_TFPACKET_CBI()
+
+
+#define UNPACK_TFPACKET_END5()                    \
+  double* send5 = tf_packet->send5;               \
+  double* hend5 = tf_packet->hend5;               \
+  double* entropyDPT = tf_packet->entropyDPT;     \
+  double* enthalpyDPT = tf_packet->enthalpyDPT;   \
+  unsigned char* numSeq1 = tf_packet->numSeq1;    \
+  int len3 = tf_packet->len3;                     \
+  double dplx_init_S = tf_packet->dplx_init_S;    \
+  double dplx_init_H = tf_packet->dplx_init_H;    \
+  double RC = tf_packet->RC;
+
+
+/* Returns thermodynamic value (S) for 5' dangling end */
+#define Sd5(i, j, numSeq1) (dangleEntropies5[numSeq1[i]][numSeq1[j]][numSeq1[j - 1]])
+
+/* Returns thermodynamic value (H) for 5' dangling end */
+#define Hd5(i, j, numSeq1) (dangleEnthalpies5[numSeq1[i]][numSeq1[j]][numSeq1[j - 1]])
+
+/* Returns thermodynamic value (S) for 3' dangling end */
+#define Sd3(i, j, numSeq1) (dangleEntropies3[numSeq1[i]][numSeq1[i+1]][numSeq1[j]])
+
+/* Returns thermodynamic value (H) for 3' dangling end */
+#define Hd3(i, j, numSeq1) (dangleEnthalpies3[numSeq1[i]][numSeq1[i+1]][numSeq1[j]])
+
+/* Returns entropy value for terminal stack */
+#define Ststack(i, j, numSeq1) (tstack2Entropies[numSeq1[i]][numSeq1[i+1]][numSeq1[j]][numSeq1[j-1]])
+
+/* Returns enthalpy value for terminal stack */
+#define Htstack(i, j, numSeq1) (tstack2Enthalpies[numSeq1[i]][numSeq1[i+1]][numSeq1[j]][numSeq1[j-1]])
+
+
+/* table where bp-s enthalpies, that retrieve to the most stable Tm, are saved */
+#define EnthalpyDPT(i, j) enthalpyDPT[(j) + ((i-1)*len3) - (1)]
+
+/* table where bp-s entropies, that retrieve to the most stable Tm, are saved */
+#define EntropyDPT(i, j) entropyDPT[(j) + ((i-1)*len3) - (1)]
+
+/* entropies of most stable hairpin terminal bp */
+#define SEND5(i) send5[i]
+
+/* enthalpies of most stable hairpin terminal bp */
+#define HEND5(i) hend5[i]
+
+
+#define bpIndx(a, b) BPI[a][b] /* for traceing matrix BPI */
+#define atPenaltyS(a, b) atpS[a][b]
+#define atPenaltyH(a, b) atpH[a][b]
+
+/* NOTE: END5_{n}
+* Executed in calc_terminal_bp; to find structure that corresponds to max Tm for
+* terminal bp
+* END5_1(X,1/2) - 1=Enthalpy, 2=Entropy
+*/
+
+// static double
+// END5_1(
+//     int i,
+//     int hs,
+//     double* send5,
+//     double* hend5,
+//     double* entropyDPT,
+//     double* enthalpyDPT,
+//     unsigned char* numSeq1,
+//     int len3,
+//     double dplx_init_S,
+//     double dplx_init_H,
+//     double RC
+// ) {
+
+static double
+END5_1(
+    int i,
+    int hs,
+    thalflex_packet_t* tf_packet
+) {
+  /* Unpack the tf_packet boiler plate variable definition */
+  UNPACK_TFPACKET_END5()
+
+  int k;
+  double max_tm; /* energy min */
+  double T1, T2;
+  double H, S;
+  double H_max, S_max;
+  H_max = H = _INFINITY;
+  S_max = S = -1.0;
+  T1 = T2 = -_INFINITY;
+  max_tm = -_INFINITY;
+  for(k = 0; k <= i - MIN_HRPN_LOOP - 2; ++k) {
+    T1 = (HEND5(k) + dplx_init_H) /(SEND5(k) + dplx_init_S + RC);
+    T2 = (0 + dplx_init_H) /(0 + dplx_init_S + RC);
+    if(T1 >= T2) {
+      H = (
+        HEND5(k) + atPenaltyH(numSeq1[k + 1], numSeq1[i]) +
+        EnthalpyDPT(k + 1, i)
+      );
+      S = (
+        SEND5(k) + atPenaltyS(numSeq1[k + 1], numSeq1[i]) +
+        EntropyDPT(k + 1, i)
+      );
+
+      if(!isFinite(H) || H > 0 || S > 0) {
+        H = _INFINITY;
+        S = -1.0;
+      }
+      T1 = (H + dplx_init_H) / (S + dplx_init_S + RC);
+    } else {
+      H = 0 + atPenaltyH(numSeq1[k + 1], numSeq1[i]) + EnthalpyDPT(k + 1, i);
+      S = 0 + atPenaltyS(numSeq1[k + 1], numSeq1[i]) + EntropyDPT(k + 1, i);
+
+      if(!isFinite(H) || H > 0 || S > 0) {
+        H = _INFINITY;
+        S = -1.0;
+      }
+      T1 = (H + dplx_init_H) /(S + dplx_init_S + RC);
+    }
+    if(max_tm < T1) {
+      if(S > MinEntropyCutoff) {
+        H_max = H;
+        S_max = S;
+        max_tm = T1;
+      }
+    }
+  }
+  if (hs == 1) return H_max;
+  return S_max;
+}
+
+
+static double
+END5_2(
+    int i,
+    int hs,
+    thalflex_packet_t* tf_packet
+) {
+  /* Unpack the tf_packet boiler plate variable definition */
+  UNPACK_TFPACKET_END5()
+
+  int k;
+  double max_tm;
+  double T1, T2;
+  double H, S;
+  double H_max, S_max;
+  H_max = H = _INFINITY;
+  T1 = T2 = max_tm = -_INFINITY;
+  S_max = S = -1.0;
+  for (k = 0; k <= i - MIN_HRPN_LOOP - 3; ++k) {
+    T1 = (HEND5(k) + dplx_init_H) /(SEND5(k) + dplx_init_S + RC);
+    T2 = (0 + dplx_init_H) /(0 + dplx_init_S + RC);
+    if(T1 >= T2) {
+      H = (
+        HEND5(k) + atPenaltyH(numSeq1[k + 2], numSeq1[i]) +
+        Hd5(i, k + 2, numSeq1) + EnthalpyDPT(k + 2, i)
+      );
+      S = (
+        SEND5(k) + atPenaltyS(numSeq1[k + 2], numSeq1[i]) +
+        Sd5(i, k + 2, numSeq1) + EntropyDPT(k + 2, i)
+      );
+      if(!isFinite(H) || H > 0 || S > 0) {
+        H = _INFINITY;
+        S = -1.0;
+      }
+      T1 = (H + dplx_init_H) / (S + dplx_init_S + RC);
+    } else {
+      H = (
+        0 + atPenaltyH(numSeq1[k + 2], numSeq1[i]) +
+        Hd5(i, k + 2, numSeq1) + EnthalpyDPT(k + 2, i)
+      );
+      S = (
+        0 + atPenaltyS(numSeq1[k + 2], numSeq1[i]) +
+        Sd5(i, k + 2, numSeq1) + EntropyDPT(k + 2, i)
+      );
+      if(!isFinite(H) || H > 0 || S > 0) {
+        H = _INFINITY;
+        S = -1.0;
+      }
+      T1 = (H + dplx_init_H) /(S + dplx_init_S + RC);
+    }
+    if(max_tm < T1) {
+      if(S > MinEntropyCutoff) {
+        H_max = H;
+        S_max = S;
+        max_tm = T1;
+      }
+    }
+  }
+  if (hs == 1) return H_max;
+  return S_max;
+}
+
+
+static double
+END5_3(
+    int i,
+    int hs,
+    thalflex_packet_t* tf_packet
+) {
+  /* Unpack the tf_packet boiler plate variable definition */
+  UNPACK_TFPACKET_END5();
+
+  int k;
+  double max_tm;
+  double T1, T2;
+  double H, S;
+  double H_max, S_max;
+  H_max = H = _INFINITY;;
+  T1 = T2 = max_tm = -_INFINITY;
+  S_max = S = -1.0;
+  for (k = 0; k <= i - MIN_HRPN_LOOP - 3; ++k) {
+    T1 = (HEND5(k) + dplx_init_H) /(SEND5(k) + dplx_init_S + RC);
+    T2 = (0 + dplx_init_H) /(0 + dplx_init_S + RC);
+    if(T1 >= T2) {
+      H = (
+        HEND5(k) + atPenaltyH(numSeq1[k + 1], numSeq1[i - 1]) +
+        Hd3(i - 1, k + 1, numSeq1) + EnthalpyDPT(k + 1, i - 1)
+      );
+      S = (
+        SEND5(k) + atPenaltyS(numSeq1[k + 1], numSeq1[i - 1]) +
+        Sd3(i - 1, k + 1, numSeq1) + EntropyDPT(k + 1, i - 1)
+      );
+      if(!isFinite(H) || (H > 0) || (S > 0)) {
+        H = _INFINITY;
+        S = -1.0;
+      }
+      T1 = (H + dplx_init_H) / (S + dplx_init_S + RC);
+    } else {
+      H = (
+        0 + atPenaltyH(numSeq1[k + 1], numSeq1[i - 1]) +
+        Hd3(i - 1, k + 1, numSeq1) + EnthalpyDPT(k + 1, i - 1)
+      );
+      S = (
+        0 + atPenaltyS(numSeq1[k + 1], numSeq1[i - 1]) +
+        Sd3(i - 1, k + 1, numSeq1) + EntropyDPT(k + 1, i - 1)
+      );
+      if(!isFinite(H) || (H > 0) || (S > 0)) {
+        H = _INFINITY;
+        S = -1.0;
+      }
+      T1 = (H + dplx_init_H) /(S + dplx_init_S + RC);
+    }
+    if(max_tm < T1) {
+      if(S > MinEntropyCutoff) {
+        H_max = H;
+        S_max = S;
+        max_tm = T1;
+      }
+    }
+  }
+  if (hs == 1) { return H_max; }
+  return S_max;
+}
+
+
+static double
+END5_4(
+    int i,
+    int hs,
+    thalflex_packet_t* tf_packet
+) {
+  /* Unpack the tf_packet boiler plate variable definition */
+  UNPACK_TFPACKET_END5()
+
+  int k;
+  double max_tm;
+  double T1, T2;
+  double H, S;
+  double H_max, S_max;
+  H_max = H = _INFINITY;
+  T1 = T2 = max_tm = -_INFINITY;
+  S_max = S = -1.0;
+  for(k = 0; k <= i - MIN_HRPN_LOOP - 4; ++k) {
+    T1 = (HEND5(k) + dplx_init_H) /(SEND5(k) + dplx_init_S + RC);
+    T2 = (0 + dplx_init_H) /(0 + dplx_init_S + RC);
+    if(T1 >= T2) {
+      H = (
+        HEND5(k) + atPenaltyH(numSeq1[k + 2], numSeq1[i - 1]) +
+        Htstack(i - 1, k + 2, numSeq1) +
+        EnthalpyDPT(k + 2, i - 1)
+      );
+      S = (
+        SEND5(k) +
+        atPenaltyS(numSeq1[k + 2], numSeq1[i - 1]) +
+        Ststack(i - 1, k + 2, numSeq1) + EntropyDPT(k + 2, i - 1)
+      );
+      if(!isFinite(H) || H > 0 || S > 0) {
+        H = _INFINITY;
+        S = -1.0;
+      }
+      T1 = (H + dplx_init_H) / (S + dplx_init_S + RC);
+    } else {
+      H = (
+        0 +
+        atPenaltyH(numSeq1[k + 2], numSeq1[i - 1]) +
+        Htstack(i - 1, k + 2, numSeq1) +
+        EnthalpyDPT(k + 2, i - 1)
+      );
+      S = (
+        0 +
+        atPenaltyS(numSeq1[k + 2], numSeq1[i - 1]) +
+        Ststack(i - 1, k + 2, numSeq1) +
+        EntropyDPT(k + 2, i - 1)
+      );
+      if(!isFinite(H) || H > 0 || S > 0) {
+        H = _INFINITY;
+        S = -1.0;
+      }
+      T1 = (H + dplx_init_H) /(S + dplx_init_S + RC);
+    }
+    if(max_tm < T1) {
+      if(S > MinEntropyCutoff) {
+        H_max = H;
+        S_max = S;
+        max_tm = T1;
+      }
+    }
+  }
+  if (hs == 1) {return H_max;}
+  return S_max;
+}
+
+
+/* Calculate terminal entropy S and terminal enthalpy H starting reading from
+* 5'end (Left hand/3' end - Right end)
+*/
+#define LSH(i, j, EntropyEnthalpy)                                              \
+{                                                                               \
+  double S1, H1, T1, G1;                                                        \
+  double S2, H2, T2, G2;                                                        \
+  S1 = S2 = -1.0;                                                               \
+  H1 = H2 = -_INFINITY;                                                         \
+  T1 = T2 = -_INFINITY;                                                         \
+  if (bpIndx(numSeq1[i], numSeq2[j]) == 0) {                                    \
+    EntropyDPT(i, j) = -1.0;                                                    \
+    EnthalpyDPT(i, j) = _INFINITY;                                              \
+  }                                                                             \
+  else {                                                                        \
+    S1 = (                                                                      \
+      atPenaltyS(numSeq1[i], numSeq2[j]) +                                      \
+      tstack2Entropies[numSeq2[j]][numSeq2[j-1]][numSeq1[i]][numSeq1[i-1]]      \
+    );                                                                          \
+    H1 = (                                                                      \
+      atPenaltyH(numSeq1[i], numSeq2[j]) +                                      \
+      tstack2Enthalpies[numSeq2[j]][numSeq2[j-1]][numSeq1[i]][numSeq1[i-1]]     \
+    );                                                                          \
+    G1 = H1 - (TEMP_KELVIN * S1);                                               \
+    if(!isFinite(H1) || (G1 > 0)) {                                             \
+      H1 = _INFINITY;                                                           \
+      S1 = -1.0;                                                                \
+      G1 = 1.0;                                                                 \
+    }                                                                           \
+    /** If there is two dangling ends at the same end of duplex **/             \
+    if (                                                                        \
+        (bpIndx(numSeq1[i-1], numSeq2[j-1]) != 1 ) &&                           \
+        isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]]) &&  \
+        isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])     \
+    ) {                                                                         \
+      S2 = (                                                                    \
+        atPenaltyS(numSeq1[i], numSeq2[j]) +                                    \
+        dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +              \
+        dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]]                \
+      );                                                                        \
+      H2 = (                                                                    \
+        atPenaltyH(numSeq1[i], numSeq2[j]) +                                    \
+        dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +             \
+        dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]]               \
+      );                                                                        \
+      G2 = H2 - TEMP_KELVIN*S2;                                                 \
+      if(!isFinite(H2) || (G2 > 0)) {                                           \
+        H2 = _INFINITY;                                                         \
+        S2 = -1.0;                                                              \
+        G2 = 1.0;                                                               \
+      }                                                                         \
+      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);                        \
+      if(isFinite(H1) && (G1 < 0)) {                                            \
+        T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);                      \
+        if( (T1 < T2) && (G2 < 0) ) {                                           \
+          S1 = S2;                                                              \
+          H1 = H2;                                                              \
+          T1 = T2;                                                              \
+        }                                                                       \
+      } else if(G2 < 0) {                                                       \
+        S1 = S2;                                                                \
+        H1 = H2;                                                                \
+        T1 = T2;                                                                \
+      }                                                                         \
+    } else if (                                                                 \
+        (bpIndx(numSeq1[i-1], numSeq2[j-1]) != 1) &&                            \
+        isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]])     \
+    ) {                                                                         \
+      S2 = (                                                                    \
+          atPenaltyS(numSeq1[i], numSeq2[j]) +                                  \
+          dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]]              \
+      );                                                                        \
+      H2 = (                                                                    \
+        atPenaltyH(numSeq1[i], numSeq2[j]) +                                    \
+        dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]]               \
+      );                                                                        \
+      G2 = H2 - TEMP_KELVIN * S2;                                               \
+      if(!isFinite(H2) || (G2 > 0)) {                                           \
+        H2 = _INFINITY;                                                         \
+        S2 = -1.0;                                                              \
+        G2 = 1.0;                                                               \
+      }                                                                         \
+      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);                        \
+      if(isFinite(H1) && (G1 < 0)) {                                            \
+        T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);                      \
+        if((T1 < T2) && (G2 < 0)) {                                             \
+          S1 = S2;                                                              \
+          H1 = H2;                                                              \
+          T1 = T2;                                                              \
+        }                                                                       \
+      } else if (G2 < 0){                                                       \
+        S1 = S2;                                                                \
+        H1 = H2;                                                                \
+        T1 = T2;                                                                \
+      }                                                                         \
+    } else if (                                                                 \
+        (bpIndx(numSeq1[i-1], numSeq2[j-1]) != 1) &&                            \
+        isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])     \
+    ) {                                                                         \
+      S2 = (                                                                    \
+        atPenaltyS(numSeq1[i], numSeq2[j]) +                                    \
+        dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]]                \
+      );                                                                        \
+      H2 = (                                                                    \
+        atPenaltyH(numSeq1[i], numSeq2[j]) +                                    \
+        dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]]               \
+      );                                                                        \
+      G2 = H2 - TEMP_KELVIN * S2;                                               \
+      if(!isFinite(H2) || (G2 > 0)) {                                           \
+        H2 = _INFINITY;                                                         \
+        S2 = -1.0;                                                              \
+        G2 = 1.0;                                                               \
+      }                                                                         \
+      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);                        \
+                                                                                \
+      if(isFinite(H1) && (G1 < 0)) {                                            \
+        T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);                      \
+                                                                                \
+        if(T1 < T2  && (G2 < 0)) {                                              \
+          S1 = S2;                                                              \
+          H1 = H2;                                                              \
+          T1 = T2;                                                              \
+        }                                                                       \
+                                                                                \
+      } else if(G2 < 0) {                                                       \
+        S1 = S2;                                                                \
+        H1 = H2;                                                                \
+        T1 = T2;                                                                \
+      }                                                                         \
+    }                                                                           \
+    S2 = atPenaltyS(numSeq1[i], numSeq2[j]);                                    \
+    H2 = atPenaltyH(numSeq1[i], numSeq2[j]);                                    \
+    T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);                          \
+    G1 = H1 -TEMP_KELVIN*S1;                                                    \
+    G2 = H2 -TEMP_KELVIN*S2;                                                    \
+    if (isFinite(H1)) {                                                         \
+      if(T1 < T2) {                                                             \
+        EntropyEnthalpy[0] = S2;                                                \
+        EntropyEnthalpy[1] = H2;                                                \
+      } else {                                                                  \
+        EntropyEnthalpy[0] = S1;                                                \
+        EntropyEnthalpy[1] = H1;                                                \
+      }                                                                         \
+    } else {                                                                    \
+      EntropyEnthalpy[0] = S2;                                                  \
+      EntropyEnthalpy[1] = H2;                                                  \
+    }                                                                           \
+  }                                                                             \
+}
+
+
+#define RSH(i, j, EntropyEnthalpy)                                              \
+{                                                                               \
+  double G1, G2;                                                                \
+  double S1, S2;                                                                \
+  double H1, H2;                                                                \
+  double T1, T2;                                                                \
+  S1 = S2 = -1.0;                                                               \
+  H1 = H2 = _INFINITY;                                                          \
+  T1 = T2 = -_INFINITY;                                                         \
+  if (bpIndx(numSeq1[i], numSeq2[j]) == 0) {                                    \
+    EntropyEnthalpy[0] = -1.0;                                                  \
+    EntropyEnthalpy[1] = _INFINITY;                                             \
+  } else {                                                                      \
+    S1 = (                                                                      \
+      atPenaltyS(numSeq1[i], numSeq2[j]) +                                      \
+      tstack2Entropies[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]][numSeq2[j + 1]]  \
+    );                                                                          \
+    H1 = (                                                                      \
+      atPenaltyH(numSeq1[i], numSeq2[j]) +                                      \
+      tstack2Enthalpies[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]][numSeq2[j + 1]] \
+    );                                                                          \
+    G1 = H1 - (TEMP_KELVIN * S1);                                               \
+    if(!isFinite(H1) || (G1 > 0)) {                                             \
+      H1 = _INFINITY;                                                           \
+      S1 = -1.0;                                                                \
+      G1 = 1.0;                                                                 \
+    }                                                                           \
+    if (                                                                        \
+        (bpIndx(numSeq1[i+1], numSeq2[j+1]) == 0) &&                            \
+        isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]]) &&  \
+        isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])     \
+    ) {                                                                         \
+      S2 = (                                                                    \
+        atPenaltyS(numSeq1[i], numSeq2[j]) +                                    \
+        dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +              \
+        dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]]                \
+      );                                                                        \
+      H2 = (                                                                    \
+        atPenaltyH(numSeq1[i], numSeq2[j]) +                                    \
+        dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +             \
+        dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]]               \
+      );                                                                        \
+      G2 = H2 - (TEMP_KELVIN * S2);                                             \
+      if(!isFinite(H2) || G2>0) {                                               \
+        H2 = _INFINITY;                                                         \
+        S2 = -1.0;                                                              \
+        G2 = 1.0;                                                               \
+      }                                                                         \
+      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);                        \
+      if(isFinite(H1) && (G1 < 0)) {                                            \
+        T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);                      \
+        if((T1 < T2) && (G2 < 0)) {                                             \
+          S1 = S2;                                                              \
+          H1 = H2;                                                              \
+          T1 = T2;                                                              \
+        }                                                                       \
+      } else if (G2 < 0) {                                                      \
+        S1 = S2;                                                                \
+        H1 = H2;                                                                \
+        T1 = T2;                                                                \
+      }                                                                         \
+    } else if (                                                                 \
+        (bpIndx(numSeq1[i+1], numSeq2[j+1]) == 0) &&                            \
+        isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]])     \
+    ) {                                                                         \
+      S2 = (                                                                    \
+        atPenaltyS(numSeq1[i], numSeq2[j]) +                                    \
+        dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]]                \
+      );                                                                        \
+      H2 = (                                                                    \
+        atPenaltyH(numSeq1[i], numSeq2[j]) +                                    \
+        dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]]               \
+      );                                                                        \
+      G2 = H2 - TEMP_KELVIN*S2;                                                 \
+      if(!isFinite(H2) || (G2 > 0)) {                                           \
+        H2 = _INFINITY;                                                         \
+        S2 = -1.0;                                                              \
+        G2 = 1.0;                                                               \
+      }                                                                         \
+      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);                        \
+      if(isFinite(H1) && (G1 < 0)) {                                            \
+        T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);                      \
+        if(T1 < T2 && (G2 < 0)) {                                               \
+          S1 = S2;                                                              \
+          H1 = H2;                                                              \
+          T1 = T2;                                                              \
+        }                                                                       \
+      } else if (G2 < 0){                                                       \
+        S1 = S2;                                                                \
+        H1 = H2;                                                                \
+        T1 = T2;                                                                \
+      }                                                                         \
+    } else if (                                                                 \
+        (bpIndx(numSeq1[i+1], numSeq2[j+1]) == 0) &&                            \
+        isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])     \
+    ) {                                                                         \
+      S2 = (                                                                    \
+        atPenaltyS(numSeq1[i], numSeq2[j]) +                                    \
+        dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]]                \
+      );                                                                        \
+      H2 = (                                                                    \
+        atPenaltyH(numSeq1[i], numSeq2[j]) +                                    \
+        dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]]               \
+      );                                                                        \
+      G2 = H2 - TEMP_KELVIN*S2;                                                 \
+      if (!isFinite(H2) || (G2 > 0)) {                                          \
+        H2 = _INFINITY;                                                         \
+        S2 = -1.0;                                                              \
+        G2 = 1.0;                                                               \
+      }                                                                         \
+      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);                        \
+      if (isFinite(H1) && (G1 < 0)) {                                           \
+        T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);                      \
+        if ((T1 < T2) && (G2 < 0)) {                                            \
+          S1 = S2;                                                              \
+          H1 = H2;                                                              \
+          T1 = T2;                                                              \
+        }                                                                       \
+      } else if (G2 < 0) {                                                      \
+        S1 = S2;                                                                \
+        H1 = H2;                                                                \
+        T1 = T2;                                                                \
+      }                                                                         \
+    }                                                                           \
+    S2 = atPenaltyS(numSeq1[i], numSeq2[j]);                                    \
+    H2 = atPenaltyH(numSeq1[i], numSeq2[j]);                                    \
+    T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);                          \
+    G1 = H1 -TEMP_KELVIN*S1;                                                    \
+    G2 =  H2 -TEMP_KELVIN*S2;                                                   \
+    if(isFinite(H1)) {                                                          \
+      if(T1 < T2) {                                                             \
+        EntropyEnthalpy[0] = S2;                                                \
+        EntropyEnthalpy[1] = H2;                                                \
+      } else {                                                                  \
+        EntropyEnthalpy[0] = S1;                                                \
+        EntropyEnthalpy[1] = H1;                                                \
+      }                                                                         \
+    } else {                                                                    \
+      EntropyEnthalpy[0] = S2;                                                  \
+      EntropyEnthalpy[1] = H2;                                                  \
+    }                                                                           \
+  }                                                                             \
+}
+
+
+/* Finds max Tm while filling the dyn progr table using stacking S and stacking
+* H (dimer)
+*/
+static void
+maxTM(
+  int i,
+  int j,
+  double* entropyDPT,
+  double* enthalpyDPT,
+  unsigned char* numSeq1,
+  int len1,
+  unsigned char* numSeq2,
+  int len2,
+  int len3,
+  double dplx_init_S,
+  double dplx_init_H,
+  double RC
+) {
+  double T0, T1;
+  double S0, S1;
+  double H0, H1;
+  double* SH;
+  SH = (double*) safe_malloc(2 * sizeof(double), 0);
+  T0 = T1 = -_INFINITY;
+  S0 = EntropyDPT(i, j);
+  H0 = EnthalpyDPT(i, j);
+  RSH(i, j, SH);
+  T0 = (H0 + dplx_init_H + SH[1]) /(S0 + dplx_init_S + SH[0] + RC);
+  if (
+      isFinite(EnthalpyDPT(i - 1, j - 1)) &&
+      isFinite(Hs(i - 1, j - 1, 1, numSeq1, len1, numSeq2, len2))
+  ) {
+    S1 = (
+      EntropyDPT(i - 1, j - 1) +
+      Ss(i - 1, j - 1, 1, numSeq1, len1, numSeq2, len2)
+    );
+    H1 = (
+      EnthalpyDPT(i - 1, j - 1) +
+      Hs(i - 1, j - 1, 1, numSeq1, len1, numSeq2, len2)
+    );
+    T1 = (H1 + dplx_init_H + SH[1]) /(S1 + dplx_init_S + SH[0] + RC);
+  } else {
+    S1 = -1.0;
+    H1 = _INFINITY;
+    T1 = (H1 + dplx_init_H) /(S1 + dplx_init_S + RC);
+  }
+  if (S1 < MinEntropyCutoff) {
+    /* to not give dH any value if dS is unreasonable */
+    S1 = MinEntropy;
+    H1 = 0.0;
+  }
+  if (S0 < MinEntropyCutoff) {
+    /* to not give dH any value if dS is unreasonable */
+    S0 = MinEntropy;
+    H0 = 0.0;
+  }
+  if(T1 > T0) {
+    EntropyDPT(i, j) = S1;
+    EnthalpyDPT(i, j) = H1;
+  } else if (T0 >= T1) {
+    EntropyDPT(i, j) = S0;
+    EnthalpyDPT(i, j) = H0;
+  }
+  free(SH);
+}
+
+
+/* Finds max Tm while filling the dyn progr table using stacking S and stacking
+* H (monomer)
+*/
+static void
+maxTM2(
+  int i,
+  int j,
+  double* entropyDPT,
+  double* enthalpyDPT,
+  unsigned char* numSeq1,
+  int len1,
+  unsigned char* numSeq2,
+  int len2,
+  int len3,
+  double dplx_init_S,
+  double dplx_init_H,
+  double RC
+) {
+  double T0, T1;
+  double S0, S1;
+  double H0, H1;
+  T0 = T1 = -_INFINITY;
+  S0 = EntropyDPT(i, j);
+  H0 = EnthalpyDPT(i, j);
+  T0 = (H0 + dplx_init_H) /(S0 + dplx_init_S + RC);
+  if (isFinite(EnthalpyDPT(i, j))) {
+    S1 = (
+      EntropyDPT(i + 1, j - 1) +
+      Ss(i, j, 2, numSeq1, len1, numSeq2, len2)
+    );
+    H1 = (
+      EnthalpyDPT(i + 1, j - 1) +
+      Hs(i, j, 2, numSeq1, len1, numSeq2, len2)
+    );
+  } else {
+    S1 = -1.0;
+    H1 = _INFINITY;
+  }
+  T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
+  if (S1 < MinEntropyCutoff) {
+    S1 = MinEntropy;
+    H1 = 0.0;
+  }
+  if (S0 < MinEntropyCutoff) {
+    S0 = MinEntropy;
+    H0 = 0.0;
+  }
+
+  if (T1 > T0) {
+    EntropyDPT(i, j) = S1;
+    EnthalpyDPT(i, j) = H1;
+  } else {
+    EntropyDPT(i, j) = S0;
+    EnthalpyDPT(i, j) = H0;
+  }
+}
+
+
+static double
+Ss(
+  int i, int j, int k,
+  unsigned char* numSeq1, int len1,
+  unsigned char* numSeq2, int len2
+) {
+  if (k == 2) {
+    if (i >= j) {
+      return -1.0;
+    }
+    if ((i == len1) || (j == len2 + 1)) {
+      return -1.0;
+    }
+
+    if (i > len1) {
+      i -= len1;
+    }
+    if (j > len2) {
+      j -= len2;
+    }
+    return stackEntropies[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]][numSeq2[j - 1]];
+  } else {
+    return stackEntropies[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]][numSeq2[j + 1]];
+  }
+}
+
+
+static double
+Hs(
+    int i, int j, int k,
+    unsigned char* numSeq1, int len1,
+    unsigned char* numSeq2, int len2
+) {
+  if(k==2) {
+    if (i >= j) {
+      return _INFINITY;
+    }
+    if (i == len1 || j == len2 + 1) {
+      return _INFINITY;
+    }
+
+    if (i > len1) {
+      i -= len1;
+    }
+    if (j > len2) {
+      j -= len2;
+    }
+    double check = stackEnthalpies[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]][numSeq2[j - 1]];
+    if(isFinite(check)) {
+      return check;
+    } else {
+      return _INFINITY;
+    }
+  } else {
+    return stackEnthalpies[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]][numSeq2[j + 1]];
+  }
+}
+
+
+/* Carries out Bulge and Internal loop and stack calculations to hairpin */
+static void
+CBI(
+  int i, int j,
+  double* EntropyEnthalpy,
+  int traceback, int maxLoop,
+  thalflex_packet_t* tf_packet
+) {
+  /* Unpack the tf_packet boiler plate variable definition */
+  UNPACK_TFPACKET_CBI()
+
+  int d, ii, jj;
+  for (d = j - i - 3; d >= MIN_HRPN_LOOP + 1 && d >= j - i - 2 - maxLoop; --d) {
+    for (ii = i + 1; ii < j - d && ii <= len1; ++ii) {
+      jj = d + ii;
+      if(traceback==0) {
+        EntropyEnthalpy[0] = -1.0;
+        EntropyEnthalpy[1] = _INFINITY;
+      }
+
+      if (isFinite(EnthalpyDPT(ii, jj)) && isFinite(EnthalpyDPT(i, j))) {
+        calc_bulge_internal2(
+            i, j, ii, jj,
+            EntropyEnthalpy,
+            traceback, maxLoop,
+            numSeq1, len1,
+            numSeq2, len2,
+            len3,
+            entropyDPT, enthalpyDPT,
+            dplx_init_S, dplx_init_H, RC
+        );
+        if(isFinite(EntropyEnthalpy[1])) {
+          if(EntropyEnthalpy[0] < MinEntropyCutoff) {
+            EntropyEnthalpy[0] = MinEntropy;
+            EntropyEnthalpy[1] = 0.0;
+          }
+          if(traceback == 0) {
+            EnthalpyDPT(i, j) = EntropyEnthalpy[1];
+            EntropyDPT(i, j) = EntropyEnthalpy[0];
+          }
+        }
+      }
+    }
+  }
+}
+
+
+#endif

--- a/primer3/src/libprimer3/thalflexsignatures.h
+++ b/primer3/src/libprimer3/thalflexsignatures.h
@@ -1,0 +1,417 @@
+/* libprimer3/thalflexsignatures.h
+
+ Copyright (c) 1996,1997,1998,1999,2000,2001,2004,2006,2007,2009,2010,
+               2011,2012,2016
+ Whitehead Institute for Biomedical Research, Steve Rozen
+ (http://purl.com/STEVEROZEN/), and Helen Skaletsky
+ All rights reserved.
+
+       This file is part of primer3 software suite.
+
+       This software suite is is free software;
+       you can redistribute it and/or modify it under the terms
+       of the GNU General Public License as published by the Free
+       Software Foundation; either version 2 of the License, or (at
+       your option) any later version.
+
+       This software is distributed in the hope that it will be useful,
+       but WITHOUT ANY WARRANTY; without even the implied warranty of
+       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+       GNU General Public License for more details.
+
+       You should have received a copy of the GNU General Public License
+       along with this software (file gpl-2.0.txt in the source
+       distribution); if not, write to the Free Software
+       Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON A THEORY
+ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Modifications to thal.c code to create thalflexsignatures.h.
+Copyright (C) 2023. Ben Pruitt & Nick Conway;
+
+See thalflex.c for more info on thalflexsignatures.h
+*/
+#ifndef _P3PY_THALFLEXSIG_H
+#define _P3PY_THALFLEXSIG_H
+
+#include <stdio.h>
+#include "thal.h"
+
+/*** BEGIN STRUCTs ***/
+
+typedef struct triloop_t {
+  char loop[5];
+  double value;
+}  triloop_t;
+
+typedef struct tetraloop_t {
+  char loop[6];
+  double value;
+} tetraloop_t;
+
+struct tracer /* structure for tracebacku - unimolecular str */ {
+  int i;
+  int j;
+  int mtrx; /* [0 1] EntropyDPT/EnthalpyDPT*/
+  struct tracer* next;
+};
+
+/*** END STRUCTs ***/
+
+/* returns length of unsigned char; to avoid warnings while compiling */
+static int length_unsig_char(const unsigned char * str);
+
+/* converts DNA sequence to int; 0-A, 1-C, 2-G, 3-T, 4-whatever */
+static unsigned char str2int(char c);
+
+/* part of calculating salt correction for Tm by SantaLucia et al */
+static double saltCorrectS (double mv, double dv, double dntp);
+
+/* file of thermodynamic params */
+static char* readParamFile(const char* dirname, const char* fname, thal_results* o);
+
+/* get thermodynamic tables */
+static double readDouble(char **str, thal_results* o);
+
+static void readLoop(char **str, double *v1, double *v2, double *v3, thal_results *o);
+
+static int readTLoop(char **str, char *s, double *v, int triloop, thal_results *o);
+
+static void getStack(
+  double stackEntropies[5][5][5][5],
+  double stackEnthalpies[5][5][5][5],
+  const thal_parameters *tp, thal_results* o);
+
+static void getStackint2(
+  double stackEntropiesint2[5][5][5][5],
+  double stackint2Enthalpies[5][5][5][5],
+  const thal_parameters *tp, thal_results* o);
+
+static void getDangle(
+  double dangleEntropies3[5][5][5],
+  double dangleEnthalpies3[5][5][5],
+  double dangleEntropies5[5][5][5],
+  double dangleEnthalpies5[5][5][5],
+  const thal_parameters *tp, thal_results* o);
+
+static void getTstack(
+  double tstackEntropies[5][5][5][5],
+  double tstackEnthalpies[5][5][5][5],
+  const thal_parameters *tp, thal_results* o);
+
+static void getTstack2(
+  double tstack2Entropies[5][5][5][5],
+  double tstack2Enthalpies[5][5][5][5],
+  const thal_parameters *tp, thal_results* o);
+
+static void getTriloop(
+  triloop_t*,
+  triloop_t*,
+  int* num,
+  const thal_parameters *tp,
+  thal_results* o
+);
+
+static void getTetraloop(
+  tetraloop_t*,
+  tetraloop_t*,
+  int* num,
+  const thal_parameters *tp,
+  thal_results* o
+);
+
+static void getLoop(
+  double hairpinLoopEnntropies[30],
+  double interiorLoopEntropies[30],
+  double bulgeLoopEntropiess[30],
+  double hairpinLoopEnthalpies[30],
+  double interiorLoopEnthalpies[30],
+  double bulgeLoopEnthalpies[30],
+  const thal_parameters *tp,
+  thal_results* o
+);
+
+/* creates table of entropy values for nucleotides to which AT-penlty must be applied */
+static void tableStartATS(double atp_value, double atp[5][5]);
+
+static void tableStartATH(double atp_value, double atp[5][5]);
+
+/* checks if sequence consists of specific triloop */
+static int comp3loop(const void*, const void*);
+
+/* checks if sequence consists of specific tetraloop */
+static int comp4loop(const void*, const void*);
+
+/* initiates thermodynamic parameter tables of entropy and enthalpy for dimer */
+static void initMatrix(
+    unsigned char* numSeq1, int len1,
+    unsigned char* numSeq2, int len2,
+    int len3,
+    double* entropyDPT,
+    double* enthalpyDPT
+);
+
+/* initiates thermodynamic parameter tables of entropy and enthalpy for monomer */
+static void initMatrix2(
+    unsigned char* numSeq1, int len1,
+    unsigned char* numSeq2, int len2,
+    int len3,
+    double* entropyDPT,
+    double* enthalpyDPT
+);
+
+/* calc-s thermod values into dynamic progr table (dimer) */
+static void fillMatrix(
+    int maxLoop,
+    thal_results *o,
+    unsigned char* numSeq1, int len1,
+    unsigned char* numSeq2, int len2,
+    int len3,
+    double* entropyDPT,
+    double* enthalpyDPT,
+    double dplx_init_S,
+    double dplx_init_H,
+    double RC
+);
+
+/* calc-s thermod values into dynamic progr table (monomer) */
+static void fillMatrix2(
+    int maxLoop,
+    thal_results* o,
+    unsigned char* numSeq1, int len1,
+    unsigned char* numSeq2, int len2,
+    int len3,
+    double* entropyDPT,
+    double* enthalpyDPT,
+    double dplx_init_S,
+    double dplx_init_H,
+    double RC
+);
+
+
+/* calculates bulges and internal loops for dimer structures */
+static void calc_bulge_internal(
+    int i,
+    int j,
+    int ii,
+    int jj,
+    double* EntropyEnthalpy,
+    int traceback,
+    int maxLoop,
+    unsigned char* numSeq1,
+    int len1,
+    unsigned char* numSeq2,
+    int len2,
+    int len3,
+    double* entropyDPT,
+    double* enthalpyDPT,
+    double dplx_init_S,
+    double dplx_init_H,
+    double RC
+);
+
+/* calculates bulges and internal loops for monomer structures */
+static void calc_bulge_internal2(
+    int i,
+    int j,
+    int ii,
+    int jj,
+    double* EntropyEnthalpy,
+    int traceback,
+    int maxLoop,
+    unsigned char* numSeq1,
+    int len1,
+    unsigned char* numSeq2,
+    int len2,
+    int len3,
+    double* entropyDPT,
+    double* enthalpyDPT,
+    double dplx_init_S,
+    double dplx_init_H,
+    double RC
+);
+
+
+/* finds monomer structure that has maximum Tm */
+static void calc_hairpin(
+    int i,
+    int j,
+    double* EntropyEnthalpy,
+    int traceback,
+    unsigned char* numSeq1,
+    int len1,
+    unsigned char* numSeq2,
+    int len2,
+    int len3,
+    double* entropyDPT,
+    double* enthalpyDPT,
+    double dplx_init_S,
+    double dplx_init_H,
+    double RC
+);
+
+/* Returns stack entropy */
+static double Ss(
+  int i, int j, int k,
+  unsigned char* numSeq1, int len1,
+  unsigned char* numSeq2, int len2
+);
+
+/* Returns stack enthalpy */
+static double Hs(
+    int i, int j, int k,
+    unsigned char* numSeq1, int len1,
+    unsigned char* numSeq2, int len2
+);
+
+static void reverse(unsigned char *s);
+
+static int max5(double, double, double, double, double);
+
+/* Is sequence symmetrical */
+static int symmetry_thermo(const unsigned char* seq);
+
+/* traceback for dimers */
+static void traceback(
+    int i,
+    int j,
+    int* ps1,
+    int* ps2,
+    int maxLoop,
+    thal_results* o,
+    double* entropyDPT,
+    double* enthalpyDPT,
+    unsigned char* numSeq1,
+    int len1,
+    unsigned char* numSeq2,
+    int len2,
+    int len3,
+    double dplx_init_S,
+    double dplx_init_H,
+    double RC
+);
+
+/* traceback for hairpins */
+static void tracebacku(
+    int* bp,
+    int maxLoop,
+    thal_results* o,
+    double* send5,
+    double* hend5,
+    double* entropyDPT,
+    double* enthalpyDPT,
+    unsigned char* numSeq1,
+    int len1,
+    unsigned char* numSeq2,
+    int len2,
+    int len3,
+    double dplx_init_S,
+    double dplx_init_H,
+    double RC
+);
+
+/* calculates but does not print dimer structure */
+/* primer3-py special function */
+static void calcDimer(
+    int* ps1,
+    int* ps2,
+    double temp,
+    double H,
+    double S,
+    int temponly,
+    double t37,
+    thal_results *o,
+    int len1,
+    int len2,
+    double saltCorrection,
+    double RC
+);
+
+/* prints ascii output of dimer structure */
+/* primer3-py special function */
+static void drawDimer(
+    int* ps1,
+    int* ps2,
+    double temp,
+    double H,
+    double S,
+    int temponly,
+    double t37,
+    thal_results *o,
+    unsigned char* oligo1,
+    int len1,
+    unsigned char* oligo2,
+    int len2,
+    double saltCorrection,
+    double RC
+);
+
+/* calculates but does not print hairpin structure */
+/* primer3-py special function */
+static void calcHairpin(
+    int* bp,
+    double mh,
+    double ms,
+    int temponly,
+    double temp,
+    thal_results *o,
+    int len1,
+    double saltCorrection
+);
+
+/* prints ascii output of hairpin structure */
+/* primer3-py special function */
+static void drawHairpin(
+    int* bp,
+    double mh,
+    double ms,
+    int temponly,
+    double temp,
+    thal_results* o,
+    unsigned char* oligo1,
+    int len1,
+    double saltCorrection
+);
+
+int trim_trailing_whitespace(char *msg, size_t msg_len);
+
+static int equal(double a, double b);
+
+/* To add elements to struct */
+static void push(struct tracer**, int, int, int, thal_results*);
+
+/* terminal bp for monomer structure */
+static void calc_terminal_bp(
+    double temp,
+    double* send5,
+    double* hend5,
+    double* entropyDPT,
+    double* enthalpyDPT,
+    unsigned char* numSeq1,
+    int len1,
+    unsigned char* numSeq2,
+    int len2,
+    int len3,
+    double dplx_init_S,
+    double dplx_init_H,
+    double RC
+);
+
+
+/* memory stuff */
+static void* safe_calloc(size_t, size_t, thal_results* o);
+static void* safe_malloc(size_t, thal_results* o);
+static void* safe_realloc(void*, size_t, thal_results* o);
+static double* safe_recalloc(double* ptr, int m, int n, thal_results* o);
+
+#endif

--- a/primer3/thermoanalysis.pxd
+++ b/primer3/thermoanalysis.pxd
@@ -84,10 +84,10 @@ cdef extern from "thal.h":
         char* tstack2_dh
         char* tstack2_ds
 
-    int  thal_set_null_parameters(thal_parameters *a)
-    int  thal_load_parameters(const char *path, thal_parameters *a, thal_results* o)
-    int  thal_free_parameters(thal_parameters *a)
-    int  get_thermodynamic_values(const thal_parameters *tp, thal_results *o)
+    int thal_set_null_parameters(thal_parameters *a)
+    int thal_load_parameters(const char *path, thal_parameters *a, thal_results* o)
+    int thal_free_parameters(thal_parameters *a)
+    int get_thermodynamic_values(const thal_parameters *tp, thal_results *o)
     void destroy_thal_structures()
 
     void thal(
@@ -98,7 +98,7 @@ cdef extern from "thal.h":
         thal_results*,
         const int,
         # char*,
-    )
+    ) nogil
 
 
 cdef extern from "oligotm.h":
@@ -128,7 +128,7 @@ cdef extern from "oligotm.h":
             tm_method_type  tm_method,              # See description above.
             salt_correction_type salt_corrections,  # See description above.
             double annealing_temp  # Actual annealing temperature of the PCR reaction
-    )
+    ) nogil
 
     int set_default_thal_parameters(thal_parameters *a)
 

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,16 @@ LIBPRIMER3_C_FPS = [
     rpath(pjoin(LIBPRIMER3_PATH, 'thal_parameters.c')),
 ]
 
+LIBPRIMER3_C_FPS_FLEX = [
+    rpath(pjoin(LIBPRIMER3_PATH, 'dpal.c')),
+    rpath(pjoin(LIBPRIMER3_PATH, 'libprimer3.c')),
+    rpath(pjoin(LIBPRIMER3_PATH, 'oligotm.c')),
+    rpath(pjoin(LIBPRIMER3_PATH, 'p3_seq_lib.c')),
+    rpath(pjoin(LIBPRIMER3_PATH, 'read_boulder.c')),
+    rpath(pjoin(LIBPRIMER3_PATH, 'thalflex.c')),
+    rpath(pjoin(LIBPRIMER3_PATH, 'thal_parameters.c')),
+]
+
 LIBPRIMER3_H_FPS = [
     rpath(pjoin(LIBPRIMER3_PATH, 'amplicontm.h')),
     rpath(pjoin(LIBPRIMER3_PATH, 'dpal.h')),
@@ -98,6 +108,8 @@ LIBPRIMER3_H_FPS = [
     rpath(pjoin(LIBPRIMER3_PATH, 'print_boulder.h')),
     rpath(pjoin(LIBPRIMER3_PATH, 'read_boulder.h')),
     rpath(pjoin(LIBPRIMER3_PATH, 'thal.h')),
+    rpath(pjoin(LIBPRIMER3_PATH, 'thalflex.h')),
+    rpath(pjoin(LIBPRIMER3_PATH, 'thalflexsignatures.h')),
     rpath(pjoin(LIBPRIMER3_PATH, 'thal_parameters.h')),
 ]
 
@@ -112,6 +124,7 @@ LIBPRIMER3_C_EXTRA_FPS = [
     rpath(pjoin(LIBPRIMER3_PATH, 'long_seq_tm_test_main.c')),
     rpath(pjoin(LIBPRIMER3_PATH, 'oligotm_main.c')),
     rpath(pjoin(LIBPRIMER3_PATH, 'primer3_boulder_main.c')),
+    rpath(pjoin(LIBPRIMER3_PATH, 'thal.c')),
     rpath(pjoin(LIBPRIMER3_PATH, 'thal_main.c')),
 
     rpath(pjoin(LIBPRIMER3_PATH, 'MAKEFILE')),
@@ -133,6 +146,7 @@ if WINDOWS_OS:
     LIBPRIMER3_BINARIES = [bin_fn + '.exe' for bin_fn in LIBPRIMER3_BINARIES]
 else:
     LIBPRIMER3_C_FPS.append(rpath(pjoin(LIBPRIMER3_PATH, 'masker.c')))
+    LIBPRIMER3_C_FPS_FLEX.append(rpath(pjoin(LIBPRIMER3_PATH, 'masker.c')))
     LIBPRIMER3_BINARIES.append('primer3_masker')
 
 LIBPRIMER3_BINARY_FPS = [
@@ -152,7 +166,7 @@ LIBPRIMER3_TEST_FPS = [
 PACKAGE_FPS = (
     LIBPRIMER3_THERMO_PARAMS_FPS +
     LIBPRIMER3_TEST_FPS +
-    LIBPRIMER3_C_FPS +
+    LIBPRIMER3_C_FPS_FLEX +
     LIBPRIMER3_C_EXTRA_FPS +
     LIBPRIMER3_H_FPS +
     KLIB_H_FPS +
@@ -287,7 +301,9 @@ cython_extensions = [
     ),
     Extension(
         'primer3.thermoanalysis',
-        sources=[pjoin('primer3', 'thermoanalysis.pyx')] + LIBPRIMER3_C_FPS,
+        sources=(
+            [pjoin('primer3', 'thermoanalysis.pyx')] + LIBPRIMER3_C_FPS_FLEX
+        ),
         include_dirs=[SRC_PATH, LIBPRIMER3_PATH, KLIB_PATH],
         extra_compile_args=EXTRA_COMPILE_ARGS,
     ),

--- a/tests/test_threadsafe.py
+++ b/tests/test_threadsafe.py
@@ -1,0 +1,219 @@
+# Copyright (C) 2023. Ben Pruitt & Nick Conway;
+# See LICENSE for full GPLv2 license.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+'''
+tests.test_threadsafe
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unit tests for the :class:`thermoanalysis.ThermoAnalysis` calls are thread-safe
+using the new `thalflex` code
+
+NOTE: It's challenging to get a race condition to compromise thread safety
+as the thal() calls are very fast
+
+'''
+import random
+import threading
+import time
+import unittest
+from typing import (
+    Any,
+    Dict,
+)
+
+from primer3 import thermoanalysis  # type: ignore
+
+
+def make_random_params() -> Dict[str, Any]:
+    '''
+    Returns:
+        dictionary of random parameters for a call  to
+        :meth`ThermoAnalysis.set_thermo_args`
+
+    '''
+    return dict(
+        mv_conc=random.uniform(1, 200),
+        dv_conc=random.uniform(0, 40),
+        dntp_conc=random.uniform(0, 20),
+        dna_conc=random.uniform(0, 200),
+        temp_c=random.randint(10, 70),
+        max_loop=random.randint(10, 30),
+    )
+
+
+def make_rand_seq_pair() -> Dict[str, str]:
+    '''
+    Returns:
+        dictionary of 2 unique sequences keyed by seq1 and seq2
+
+    '''
+    return dict(
+        seq1=''.join([
+            random.choice('ATGC') for _ in
+            range(random.randint(20, 59))
+        ]),
+        seq2=''.join([
+            random.choice('ATGC') for _ in
+            range(random.randint(20, 59))
+        ]),
+    )
+
+
+class TestThermoAnalysisInThread(unittest.TestCase):
+
+    def test_calc_heterodimer_in_thread(self):
+        '''Test basic heterodimer input in a thread
+
+        '''
+        def het_thread(
+                _results_list,
+                i,
+        ):
+            _taf = thermoanalysis.ThermoAnalysis()
+            _params = make_random_params()
+            _taf.set_thermo_args(
+                **_params,
+            )
+            _seq_pair = make_rand_seq_pair()
+            _res = _taf.calc_heterodimer(
+                **_seq_pair,
+            )
+            _results_list[i] = (_res, _params, _seq_pair)
+
+        thread_count = 10
+        results_list = [None] * thread_count
+        thread_list = []
+        t0 = time.time()
+        # 1. Run in threads
+        for i in range(thread_count):
+            t = threading.Thread(
+                target=het_thread,
+                args=(results_list, i),
+            )
+            thread_list.append(t)
+            t.start()
+
+        for t in thread_list:
+            t.join()
+
+        print(f'total: {(time.time()-t0):0.2}')
+
+        taf = thermoanalysis.ThermoAnalysis()
+        t0 = time.time()
+
+        # 2. Compare threaded results to sequential results
+        for res, params, seq_pair in results_list:
+            taf.set_thermo_args(
+                **params,
+            )
+            new_res = taf.calc_heterodimer(
+                **seq_pair,
+            )
+            self.assertEqual(new_res.tm, res.tm)
+            self.assertEqual(new_res.dh, res.dh)
+        print(f'total: {(time.time()-t0):0.2}')
+
+        def tdesign_run(_global_args, _results_list, i):
+            sequence_template = (
+                'GCTTGCATGCCTGCAGGTCGACTCTAGAGGATCCCCCTACATTTTAGCATCAGTGAGTACA'
+                'GCATGCTTACTGGAAGAGAGGGTCATGCAACAGATTAGGAGGTAAGTTTGCAAAGGCAGGC'
+                'TAAGGAGGAGACGCACTGAATGCCATGGTAAGAACTCTGGACATAAAAATATTGGAAGTTG'
+                'TTGAGCAAGTNAAAAAAATGTTTGGAAGTGTTACTTTAGCAATGGCAAGAATGATAGTATG'
+                'GAATAGATTGGCAGAATGAAGGCAAAATGATTAGACATATTGCATTAAGGTAAAAAATGAT'
+                'AACTGAAGAATTATGTGCCACACTTATTAATAAGAAAGAATATGTGAACCTTGCAGATGTT'
+                'TCCCTCTAGTAG'
+            ) + ''.join([
+                random.choice('ATGC') for _ in
+                range(60)
+            ])
+            quality_list = [
+                random.randint(20, 90)
+                for i in range(len(sequence_template))
+            ]
+            seq_args = {
+                'SEQUENCE_ID': 'MH1000',
+                'SEQUENCE_TEMPLATE': sequence_template,
+                'SEQUENCE_QUALITY': quality_list,
+                'SEQUENCE_INCLUDED_REGION': (36, 342),
+            }
+            _taf = thermoanalysis.ThermoAnalysis()
+            result = _taf.run_design(
+                global_args=_global_args,
+                seq_args=seq_args,
+                misprime_lib=None,
+                mishyb_lib=None,
+            )
+            _results_list[i] = (result, seq_args, i)
+
+        thread_count = 10
+        results_list = [None] * thread_count
+        thread_list = []
+        t0 = time.time()
+
+        global_args = {
+            'PRIMER_OPT_SIZE': 20,
+            'PRIMER_PICK_INTERNAL_OLIGO': 1,
+            'PRIMER_INTERNAL_MAX_SELF_END': 8,
+            'PRIMER_MIN_SIZE': 18,
+            'PRIMER_MAX_SIZE': 25,
+            'PRIMER_OPT_TM': 60.0,
+            'PRIMER_MIN_TM': 57.0,
+            'PRIMER_MAX_TM': 63.0,
+            'PRIMER_MIN_GC': 20.0,
+            'PRIMER_MAX_GC': 80.0,
+            'PRIMER_MAX_POLY_X': 100,
+            'PRIMER_INTERNAL_MAX_POLY_X': 100,
+            'PRIMER_SALT_MONOVALENT': 50.0,
+            'PRIMER_DNA_CONC': 50.0,
+            'PRIMER_MAX_NS_ACCEPTED': 0,
+            'PRIMER_MAX_SELF_ANY': 12,
+            'PRIMER_MAX_SELF_END': 8,
+            'PRIMER_PAIR_MAX_COMPL_ANY': 12,
+            'PRIMER_PAIR_MAX_COMPL_END': 8,
+            'PRIMER_PRODUCT_SIZE_RANGE': [
+                [75, 100],
+                [100, 125],
+                [125, 150],
+                [150, 175],
+                [175, 200],
+                [200, 225],
+            ],
+        }
+
+        # 3. Run in threads
+        t0 = time.time()
+        for i in range(thread_count):
+            t = threading.Thread(
+                target=tdesign_run,
+                args=(global_args, results_list, i),
+            )
+            thread_list.append(t)
+            t.start()
+        print(f'total: {(time.time()-t0):0.2}')
+
+        taf = thermoanalysis.ThermoAnalysis()
+        t0 = time.time()
+        # 4. Compare threaded results to sequential results
+        for res, seq_args, i in results_list:
+            new_res = taf.run_design(
+                global_args=global_args,
+                seq_args=seq_args,
+                misprime_lib=None,
+                mishyb_lib=None,
+            )
+            self.assertEqual(new_res, res)
+        print(f'total: {(time.time()-t0):0.2}')
+        # raise ValueError('')


### PR DESCRIPTION
New `thal.c` code lives in `thalflex.c` and `thalflex.h` and `thalflexsignatures.h`.

Commented out code in `thalflex.c` used MacOS `<malloc/malloc.h>` `malloc_size()` function to investigate allocations of `triloopEnthalpies/triloopEntropies` and `tetraloopEnthalpies/tetraloopEntropies`

`test_threadsafe.py` add and `nogil` instituted for calls to `thal()` and `seqtm()` added `run_design` and `calc_heterodimer` threadsafe tests

Presently  `thermoanalysis.pyx/pxd` have been update to use `thalflex.c ` and `nogil` cython instruction resulting in a 20X speed improvement on MacOS development machine (2X from `thalflex.c` and 10X from `nogil`)

`ThermoAnalysis` class no longer needs to be a `Singleton` so this was removed as a parent class

version bump to 1.2.0a1

`CHANGES` update for 1.2.0 updates