### PR TITLE
bug fixes for issue 101. `pdh_create_seq_lib` to bug fixes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.2.1 (April 28, 2023)
+- Bug fixes for `pdh_create_seq_lib` to correct missing `seq_lib` datastructure allocation and variable name typos.
+- Increase test coverage to include `misprime_lib` and `mishyb_lib` arguments
+
 ## Version 1.2.0 (March 22, 2023)
 
 - Threadsafe changes made to `thal.c` resulting in new  `thalflex.c` and `thalflex.h` and `thalflexsignatures.h`.

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -26,7 +26,7 @@ import os
 from typing import List
 
 # Per PEP-440 https://peps.python.org/pep-0440/#public-version-identifiers
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
     'Copyright 2014-2023, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'

--- a/primer3/thermoanalysis.pxd
+++ b/primer3/thermoanalysis.pxd
@@ -141,6 +141,8 @@ cdef extern from "p3_seq_lib.h":
     ctypedef struct seq_lib:
         pass
 
+    seq_lib* create_empty_seq_lib()
+
     int seq_lib_num_seq(const seq_lib* lib)
 
     void destroy_seq_lib(seq_lib *lib)

--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -1404,15 +1404,16 @@ cdef seq_lib* pdh_create_seq_lib(object seq_dict) except NULL:
         char* seq_c = NULL
         char* errfrag = NULL
 
+    sl = create_empty_seq_lib()
     if sl == NULL:
         raise OSError('Could not allocate memory for seq_lib')
 
     for seq_name_str, seq_str in seq_dict.items():
         if isinstance(seq_name_str, str):
             seq_name_b = seq_name_str.encode('utf8')
-            seq_name = seq_name_b
+            seq_name_c = seq_name_b
         elif isinstance(seq_name_str, bytes):
-            seq_name = seq_name
+            seq_name_c = seq_name_str
         else:
             destroy_seq_lib(sl)
             raise TypeError(
@@ -1435,6 +1436,7 @@ cdef seq_lib* pdh_create_seq_lib(object seq_dict) except NULL:
             destroy_seq_lib(sl)
             raise OSError(err_msg_b.decode('utf8'))
     reverse_complement_seq_lib(sl)
+
     return sl
 
 

--- a/tests/test_primerdesign.py
+++ b/tests/test_primerdesign.py
@@ -452,6 +452,85 @@ class TestDesignBindings(unittest.TestCase):
                 f'memory leak (mem increase: {em - sm})',
             )
 
+    def test_misprime_lib_mishyb_lib(self):
+        '''Test that the misprime library and mishyb library arguments
+        successfully run through the bindings.
+
+        '''
+        seq_args = {
+            'SEQUENCE_ID': 'MH1000',
+            'SEQUENCE_TEMPLATE': (
+                'GCTTGCATGCCTGCAGGTCGACTCTAGAGGATCCCCCTACATTTT'
+                'AGCATCAGTGAGTACAGCATGCTTACTGGAAGAGAGGGTCATGCA'
+                'ACAGATTAGGAGGTAAGTTTGCAAAGGCAGGCTAAGGAGGAGACG'
+                'CACTGAATGCCATGGTAAGAACTCTGGACATAAAAATATTGGAAG'
+                'TTGTTGAGCAAGTNAAAAAAATGTTTGGAAGTGTTACTTTAGCAA'
+                'TGGCAAGAATGATAGTATGGAATAGATTGGCAGAATGAAGGCAAA'
+                'ATGATTAGACATATTGCATTAAGGTAAAAAATGATAACTGAAGAA'
+                'TTATGTGCCACACTTATTAATAAGAAAGAATATGTGAACCTTGCA'
+                'GATGTTTCCCTCTAGTAG'
+            ),
+            'SEQUENCE_INCLUDED_REGION': [36, 342],
+        }
+        global_args = {
+            'PRIMER_OPT_SIZE': 20,
+            'PRIMER_PICK_INTERNAL_OLIGO': 1,
+            'PRIMER_INTERNAL_MAX_SELF_END': 8,
+            'PRIMER_MIN_SIZE': 18,
+            'PRIMER_MAX_SIZE': 25,
+            'PRIMER_OPT_TM': 60.0,
+            'PRIMER_MIN_TM': 57.0,
+            'PRIMER_MAX_TM': 63.0,
+            'PRIMER_MIN_GC': 20.0,
+            'PRIMER_MAX_GC': 80.0,
+            'PRIMER_MAX_POLY_X': 100,
+            'PRIMER_INTERNAL_MAX_POLY_X': 100,
+            'PRIMER_SALT_MONOVALENT': 50.0,
+            'PRIMER_DNA_CONC': 50.0,
+            'PRIMER_MAX_NS_ACCEPTED': 0,
+            'PRIMER_MAX_SELF_ANY': 12,
+            'PRIMER_MAX_SELF_END': 8,
+            'PRIMER_PAIR_MAX_COMPL_ANY': 12,
+            'PRIMER_PAIR_MAX_COMPL_END': 8,
+            'PRIMER_PRODUCT_SIZE_RANGE': [
+                [75, 100], [100, 125], [125, 150],
+                [150, 175], [175, 200], [200, 225],
+            ],
+        }
+
+        result = bindings.design_primers(
+            seq_args=seq_args,
+            global_args=global_args,
+            misprime_lib={
+                'SEQ1': 'CACCATGGAGCTCCTGATATTAAAGGCGAATGCCATT',
+            },
+        )
+        self.assertEqual(result['PRIMER_PAIR_NUM_RETURNED'], 5)
+        self.assertEqual(result['PRIMER_LEFT_0'], [46, 21])
+
+        result = bindings.design_primers(
+            seq_args=seq_args,
+            global_args=global_args,
+            mishyb_lib={
+                'SEQ1': 'TTATGTGCCACACTTATTAATAAGAAAGAATATGTGAACCTTGCA',
+            },
+        )
+        self.assertEqual(result['PRIMER_PAIR_NUM_RETURNED'], 5)
+        self.assertEqual(result['PRIMER_LEFT_0'], [46, 21])
+
+        bindings.design_primers(
+            seq_args=seq_args,
+            global_args=global_args,
+            misprime_lib={
+                'SEQ1': 'CACCATGGAGCTCCTGATATTAAAGGCGAATGCCATT',
+            },
+            mishyb_lib={
+                'SEQ1': 'TTATGTGCCACACTTATTAATAAGAAAGAATATGTGAACCTTGCA',
+            },
+        )
+        self.assertEqual(result['PRIMER_PAIR_NUM_RETURNED'], 5)
+        self.assertEqual(result['PRIMER_LEFT_0'], [46, 21])
+
 
 def suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
`pdh_create_seq_lib` updated to correct missing `seq_lib` datastructure allocation and variable name typos.

Increase test coverage to include `misprime_lib` and `mishyb_lib` arguments

version bump to 1.2.1