### PR TITLE
Output-related bug fixes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.2.2 (May 16, 2023)
+- Bug fixes for output formatting related to penalty, "problem", and mispriming fields
+
 ## Version 1.2.1 (April 28, 2023)
 - Bug fixes for `pdh_create_seq_lib` to correct missing `seq_lib` datastructure allocation and variable name typos.
 - Increase test coverage to include `misprime_lib` and `mishyb_lib` arguments

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -26,7 +26,7 @@ import os
 from typing import List
 
 # Per PEP-440 https://peps.python.org/pep-0440/#public-version-identifiers
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
     'Copyright 2014-2023, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'

--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -1689,7 +1689,7 @@ cdef object pdh_design_output_to_dict(
 
         if go_int == 1:
             temp_double = intl[0].quality
-            output_dict[f'PRIMER_RIGHT{int_oligo}_{i}_PENALTY'] = temp_double
+            output_dict[f'PRIMER_{int_oligo}_{i}_PENALTY'] = temp_double
 
         # Print the oligo_problems
         if (go_fwd == 1) and p3_ol_has_any_problem(fwd):
@@ -1702,7 +1702,7 @@ cdef object pdh_design_output_to_dict(
 
         if (go_int == 1) and p3_ol_has_any_problem(intl):
             problem_b = <bytes> p3_get_ol_problem_string(intl)
-            output_dict[f'PRIMER_RIGHT{int_oligo}_{i}_PROBLEMS'] = problem_b
+            output_dict[f'PRIMER_{int_oligo}_{i}_PROBLEMS'] = problem_b
 
 
         # Print primer sequences.
@@ -1921,21 +1921,21 @@ cdef object pdh_design_output_to_dict(
         if seq_lib_num_seq(global_settings_data[0].p_args.repeat_lib) > 0:
             if go_fwd == 1:
                 sqtemp_b = <bytes> fwd[0].repeat_sim.name
-                output_dict['PRIMER_LEFT_{i}_LIBRARY_MISPRIMING'] = (
+                output_dict[f'PRIMER_LEFT_{i}_LIBRARY_MISPRIMING'] = (
                     fwd[0].repeat_sim.score[fwd[0].repeat_sim.max],
                     sqtemp_b.decode('utf8'),
                 )
 
             if go_rev == 1:
                 sqtemp_b = <bytes> rev[0].repeat_sim.name
-                output_dict['PRIMER_RIGHT_{i}_LIBRARY_MISPRIMING'] = (
+                output_dict[f'PRIMER_RIGHT_{i}_LIBRARY_MISPRIMING'] = (
                     rev[0].repeat_sim.score[rev[0].repeat_sim.max],
                     sqtemp_b.decode('utf8'),
                 )
 
             if retval[0].output_type == p3_output_type.primer_pairs:
                 sqtemp_b = <bytes> retval[0].best_pairs.pairs[i].rep_name
-                output_dict['PRIMER_PAIR_{i}_LIBRARY_MISPRIMING'] = (
+                output_dict[f'PRIMER_PAIR_{i}_LIBRARY_MISPRIMING'] = (
                     retval[0].best_pairs.pairs[i].repeat_sim,
                     sqtemp_b.decode('utf8'),
                 )
@@ -1966,8 +1966,10 @@ cdef object pdh_design_output_to_dict(
             not pr_default_position_penalties(global_settings_data) or
             not PR_START_CODON_POS_IS_NULL(sequence_args_data)
         ):
-            output_dict[f'PRIMER_LEFT_{i}_POSITION_PENALTY'] = fwd[0].position_penalty
-            output_dict[f'PRIMER_RIGHT_{i}_POSITION_PENALTY'] = rev[0].position_penalty
+            if go_fwd == 1:
+                output_dict[f'PRIMER_LEFT_{i}_POSITION_PENALTY'] = fwd[0].position_penalty
+            if go_rev == 1:
+                output_dict[f'PRIMER_RIGHT_{i}_POSITION_PENALTY'] = rev[0].position_penalty
 
         # Print primer end stability
         if go_fwd == 1:


### PR DESCRIPTION
See #104 -- constitutes patch release:

```markdown
## Version 1.2.2 (May 16, 2023)
- Bug fixes for output formatting related to penalty, "problem", and mispriming fields
```

