### PR TITLE
hot fix for missing assignment of `no_structure` when structure is not found

### DIFF
--- a/primer3/src/libprimer3/thal.c
+++ b/primer3/src/libprimer3/thal.c
@@ -680,6 +680,7 @@ thal(const unsigned char *oligo_f,
         if (print_output == 1) { /* primer3-py update to supress undesired printing */
           fputs("No secondary structure could be calculated\n", stderr);
         }
+        o->no_structure = 1;
     }
 
     if(o->temp == -_INFINITY && (!strcmp(o->msg, ""))) { o->temp=0.0; }

--- a/primer3/src/libprimer3/thalflex.c
+++ b/primer3/src/libprimer3/thalflex.c
@@ -652,6 +652,7 @@ thal(
         if (print_output == 1) { /* primer3-py update to supress undesired printing */
           fputs("No secondary structure could be calculated\n", stderr);
         }
+        o->no_structure = 1;
     }
 
     if(o->temp == -_INFINITY && (!strcmp(o->msg, ""))) { o->temp=0.0; }


### PR DESCRIPTION
fix for issue #108 whereby `no_structure` is not correctly set to 1 when no secondary structure in found