### PR TITLE
Nested structure for primer results 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,13 @@
 # Changelog
 
-## Version 2.0.0 (May 16, 2023)
+## Version 2.0.0 (May 30, 2023)
 
 - Migrated primer3 header file Cython extern imports to `thermoanalysis.pxi`
 - Optional C structure string argument `c_ascii_structure` added to `_ThermoAnalysis` methods to enable 3rd party use for structures
 - Version bump to 2.0.0 due to breaking change
+- Fix issue whereby no_structure is not correctly 1 set to 1 when no secondary structure in found
+-  add list version of `PRIMER_{PAIR, LEFT, RIGHT, INTERNAL}` to design output dictionary keys Retaining original keys as well for compatibility.
+
 
 ## Version 1.2.2 (May 16, 2023)
 

--- a/docs/cython_help.md
+++ b/docs/cython_help.md
@@ -40,4 +40,8 @@ and to build/install using a standard `setup.py` add the lines (fill in the ...s
         ...)
 ```
 
-and it should work
+and it should work.
+
+## Notes
+- Many `_ThermoAnalysis` methods (e.g. `calc_heterodimer_c`) have C string argument
+`c_ascii_structure` to enable 3rd party use for structures reuse

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -26,7 +26,7 @@ import os
 from typing import List
 
 # Per PEP-440 https://peps.python.org/pep-0440/#public-version-identifiers
-__version__ = '2.0.0a1'
+__version__ = '2.0.0'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
     'Copyright 2014-2023, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'

--- a/tests/test_primerdesign.py
+++ b/tests/test_primerdesign.py
@@ -517,6 +517,7 @@ class TestDesignBindings(unittest.TestCase):
         )
         self.assertEqual(result['PRIMER_PAIR_NUM_RETURNED'], 5)
         self.assertEqual(result['PRIMER_LEFT_0'], [46, 21])
+        self.assertEqual(result['PRIMER_LEFT'][0]['COORDS'], [46, 21])
 
         bindings.design_primers(
             seq_args=seq_args,
@@ -528,8 +529,31 @@ class TestDesignBindings(unittest.TestCase):
                 'SEQ1': 'TTATGTGCCACACTTATTAATAAGAAAGAATATGTGAACCTTGCA',
             },
         )
+
+        self.assertAlmostEqual(
+            result['PRIMER_PAIR_0_PENALTY'],
+            1.37323,
+            places=4,
+        )
+        self.assertAlmostEqual(
+            result['PRIMER_PAIR'][0]['PENALTY'],
+            1.37323,
+            places=4,
+        )
+        self.assertEqual(len(result['PRIMER_PAIR']), 5)
+
         self.assertEqual(result['PRIMER_PAIR_NUM_RETURNED'], 5)
         self.assertEqual(result['PRIMER_LEFT_0'], [46, 21])
+        self.assertEqual(result['PRIMER_LEFT'][0]['COORDS'], [46, 21])
+        self.assertEqual(len(result['PRIMER_LEFT']), 5)
+
+        self.assertEqual(result['PRIMER_RIGHT_0'], [132, 20])
+        self.assertEqual(result['PRIMER_RIGHT'][0]['COORDS'], [132, 20])
+        self.assertEqual(len(result['PRIMER_RIGHT']), 5)
+
+        self.assertEqual(result['PRIMER_INTERNAL_0'], [69, 24])
+        self.assertEqual(result['PRIMER_INTERNAL'][0]['COORDS'], [69, 24])
+        self.assertEqual(len(result['PRIMER_INTERNAL']), 5)
 
 
 def suite():


### PR DESCRIPTION
see issue #50 

`PRIMER_{PAIR, LEFT, RIGHT, INTERNAL}` output dictionary keys. 
Retaining original keys as well for compatibility

version bump to 2.0.0

Updated `CHANGES`

Updated `cython_help.md` for a note about the `c_ascii_structure` argument from a previous PR #100 
