### PR TITLE
Hotfix `recalc_primer_sec_struct` missing `thal_result.sec_struct` initialization to `NULL`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,7 +7,7 @@
 - Version bump to 2.0.0 due to breaking change
 - Fix issue whereby no_structure is not correctly 1 set to 1 when no secondary structure in found
 -  add list version of `PRIMER_{PAIR, LEFT, RIGHT, INTERNAL}` to design output dictionary keys Retaining original keys as well for compatibility.
-
+-  Fix for  missing `thal_result.sec_struct` and `dpal_results.sec_struct` initialization to `NULL` in `recalc_primer_sec_struct`
 
 ## Version 1.2.2 (May 16, 2023)
 

--- a/primer3/src/libprimer3/libprimer3.c
+++ b/primer3/src/libprimer3/libprimer3.c
@@ -5283,8 +5283,7 @@ recalc_secundary_structures(
     num_print = retval->best_pairs.num_pairs;
     for (int i = 0 ; i < num_print ; i++) {
       recalc_primer_sec_struct(
-        retval->best_pairs.pairs[i].
-        left,
+        retval->best_pairs.pairs[i].left,
         0,
         pa,
         sa,
@@ -5381,6 +5380,10 @@ recalc_primer_sec_struct(
 
   if (pa->thermodynamic_oligo_alignment==0) {
     dpal_results any, end;
+    /* NOTE: important to set these values to NULL to prevent segfaults */
+    any.sec_struct = NULL;
+    end.sec_struct = NULL;
+
     if (p_rec->self_any > 0.0) {
       dpal((const unsigned char *) s1, (const unsigned char *) s1_rev,
            dpal_arg_to_use->local, DPM_STRUCT, &any);
@@ -5397,6 +5400,11 @@ recalc_primer_sec_struct(
   /* Thermodynamic approach, fwd-primer */
   if (pa->thermodynamic_oligo_alignment==1) {
     thal_results any, end, hair;
+    /* NOTE: important to set these values to NULL to prevent segfaults */
+    any.sec_struct = NULL;
+    end.sec_struct = NULL;
+    hair.sec_struct = NULL;
+
     if (p_rec->self_any > 0.0 ) {
       thal(
         (const unsigned char *) s1,

--- a/primer3/src/libprimer3/libprimer3flex.c
+++ b/primer3/src/libprimer3/libprimer3flex.c
@@ -6182,8 +6182,7 @@ recalc_secundary_structures(
     num_print = retval->best_pairs.num_pairs;
     for (int i = 0 ; i < num_print ; i++) {
       recalc_primer_sec_struct(
-        retval->best_pairs.pairs[i].
-        left,
+        retval->best_pairs.pairs[i].left,
         0,
         pa,
         sa,
@@ -6232,7 +6231,7 @@ recalc_primer_sec_struct(
   char s1[THAL_MAX_ALIGN+1], s1_rev[THAL_MAX_ALIGN+1];
   int overhang_len;
   /* s1 is the forward oligo. */
-  if (primer_type == 0) {  /*left */
+  if (primer_type == 0) {  /* left */
     if (NULL != sa->overhang_left) {
       overhang_len = strlen(sa->overhang_left);
       strcpy(s1, sa->overhang_left);
@@ -6287,9 +6286,11 @@ recalc_primer_sec_struct(
     }
     p3_reverse_complement(s1_rev, s1);
   }
-
   if (pa->thermodynamic_oligo_alignment==0) {
     dpal_results any, end;
+    /* NOTE: important to set these values to NULL to prevent segfaults */
+    any.sec_struct = NULL;
+    end.sec_struct = NULL;
     if (p_rec->self_any > 0.0) {
       dpal(
         (const unsigned char*) s1,
@@ -6322,6 +6323,11 @@ recalc_primer_sec_struct(
   /* Thermodynamic approach, fwd-primer */
   if (pa->thermodynamic_oligo_alignment==1) {
     thal_results any, end, hair;
+    /* NOTE: important to set these values to NULL to prevent segfaults */
+    any.sec_struct = NULL;
+    end.sec_struct = NULL;
+    hair.sec_struct = NULL;
+
     if (p_rec->self_any > 0.0 ) {
       thal(
         (const unsigned char*) s1,

--- a/primer3/src/libprimer3/thal.c
+++ b/primer3/src/libprimer3/thal.c
@@ -496,7 +496,7 @@ thal(const unsigned char *oligo_f,
      const thal_args *a,
      const thal_mode mode,
      thal_results *o,
-     const int print_output)  /* primer3-py modification argumen */
+     const int print_output)  /* primer3-py modification argument */
 {
   double* SH;
   int i, j;

--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -1279,6 +1279,7 @@ cdef class _ThermoAnalysis:
             <p3_global_settings*> self.global_settings_data,
             <seq_args_t*> self.sequence_args_data,
         )
+
         if retval == NULL:
             raise ValueError('Issue choosing primers')
         try:

--- a/tests/test_primerdesign.py
+++ b/tests/test_primerdesign.py
@@ -555,6 +555,56 @@ class TestDesignBindings(unittest.TestCase):
         self.assertEqual(result['PRIMER_INTERNAL'][0]['COORDS'], [69, 24])
         self.assertEqual(len(result['PRIMER_INTERNAL']), 5)
 
+    def test_PRIMER_SECONDARY_STRUCTURE_ALIGNMENT(self):
+        '''Ensure all result pointers are initialized to NULL.
+        '''
+        seq_args = {
+            'SEQUENCE_ID': 'MH1000',
+            'SEQUENCE_TEMPLATE': (
+                'GCTTGCATGCCTGCAGGTCGACTCTAGAGGATCCCCCTACATTTT'
+                'AGCATCAGTGAGTACAGCATGCTTACTGGAAGAGAGGGTCATGCA'
+                'ACAGATTAGGAGGTAAGTTTGCAAAGGCAGGCTAAGGAGGAGACG'
+                'CACTGAATGCCATGGTAAGAACTCTGGACATAAAAATATTGGAAG'
+                'TTGTTGAGCAAGTNAAAAAAATGTTTGGAAGTGTTACTTTAGCAA'
+                'TGGCAAGAATGATAGTATGGAATAGATTGGCAGAATGAAGGCAAA'
+                'ATGATTAGACATATTGCATTAAGGTAAAAAATGATAACTGAAGAA'
+                'TTATGTGCCACACTTATTAATAAGAAAGAATATGTGAACCTTGCA'
+                'GATGTTTCCCTCTAGTAG'
+            ),
+            'SEQUENCE_INCLUDED_REGION': [36, 342],
+        }
+        global_args = {
+            'PRIMER_SECONDARY_STRUCTURE_ALIGNMENT': 1,  # key parameter for test
+            'PRIMER_OPT_SIZE': 20,
+            'PRIMER_PICK_INTERNAL_OLIGO': 1,
+            'PRIMER_INTERNAL_MAX_SELF_END': 8,
+            'PRIMER_MIN_SIZE': 18,
+            'PRIMER_MAX_SIZE': 25,
+            'PRIMER_OPT_TM': 60.0,
+            'PRIMER_MIN_TM': 57.0,
+            'PRIMER_MAX_TM': 63.0,
+            'PRIMER_MIN_GC': 20.0,
+            'PRIMER_MAX_GC': 80.0,
+            'PRIMER_MAX_POLY_X': 100,
+            'PRIMER_INTERNAL_MAX_POLY_X': 100,
+            'PRIMER_SALT_MONOVALENT': 50.0,
+            'PRIMER_DNA_CONC': 50.0,
+            'PRIMER_MAX_NS_ACCEPTED': 0,
+            'PRIMER_MAX_SELF_ANY': 12,
+            'PRIMER_MAX_SELF_END': 8,
+            'PRIMER_PAIR_MAX_COMPL_ANY': 12,
+            'PRIMER_PAIR_MAX_COMPL_END': 8,
+            'PRIMER_PRODUCT_SIZE_RANGE': [
+                [75, 100], [100, 125], [125, 150],
+                [150, 175], [175, 200], [200, 225],
+            ],
+        }
+        # This should run without a segmentation fault.
+        bindings.design_primers(
+            seq_args=seq_args,
+            global_args=global_args,
+        )
+
 
 def suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
For issue #111 to address missing `thal_result.sec_struct` and `dpal_results.sec_struct` initialization to `NULL` in `recalc_primer_sec_struct` in `libprimer3.c` and `libprimer3flex.c`

This resulted in `PRIMER_SECONDARY_STRUCTURE_ALIGNMENT` being set to 1 causing a segmentation fault.