### PR TITLE
2.0.0 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,17 @@
 # Changelog
 
+## Version 2.0.0 (May 16, 2023)
+
+- Migrated primer3 header file Cython extern imports to `thermoanalysis.pxi`
+- Optional C structure string argument `c_ascii_structure` added to `_ThermoAnalysis` methods to enable 3rd party use for structures
+- Version bump to 2.0.0 due to breaking change
+
 ## Version 1.2.2 (May 16, 2023)
+
 - Bug fixes for output formatting related to penalty, "problem", and mispriming fields
 
 ## Version 1.2.1 (April 28, 2023)
+
 - Bug fixes for `pdh_create_seq_lib` to correct missing `seq_lib` datastructure allocation and variable name typos.
 - Increase test coverage to include `misprime_lib` and `mishyb_lib` arguments
 
@@ -18,6 +26,7 @@
 - `setup.py` `package_data` and `MANIFEST.in` to assist with future builds from `tar.gz` (`conda`)
 
 ## Version 1.1.0 (March 1, 2023)
+
  - Added specificity to error non-N IUPAC error for issue #59
  - Wheel build support for python 3.8 to move towards following the CPython EOL model for issue #88. See https://devguide.python.org/versions/
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,13 @@
 # Changelog
 
-## Version 2.0.0 (May 16, 2023)
+## Version 2.0.0 (May 30, 2023)
 
 - Migrated primer3 header file Cython extern imports to `thermoanalysis.pxi`
 - Optional C structure string argument `c_ascii_structure` added to `_ThermoAnalysis` methods to enable 3rd party use for structures
 - Version bump to 2.0.0 due to breaking change
+- Fix issue whereby no_structure is not correctly 1 set to 1 when no secondary structure in found
+-  add list version of `PRIMER_{PAIR, LEFT, RIGHT, INTERNAL}` to design output dictionary keys Retaining original keys as well for compatibility.
+
 
 ## Version 1.2.2 (May 16, 2023)
 

--- a/CHANGES
+++ b/CHANGES
@@ -7,7 +7,7 @@
 - Version bump to 2.0.0 due to breaking change
 - Fix issue whereby no_structure is not correctly 1 set to 1 when no secondary structure in found
 -  add list version of `PRIMER_{PAIR, LEFT, RIGHT, INTERNAL}` to design output dictionary keys Retaining original keys as well for compatibility.
-
+-  Fix for  missing `thal_result.sec_struct` and `dpal_results.sec_struct` initialization to `NULL` in `recalc_primer_sec_struct`
 
 ## Version 1.2.2 (May 16, 2023)
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README.md LICENSE CHANGES AUTHORS setup.py
 include .pre-commit-config.yaml dev-requirements.txt setup.cfg
-include primer3/*.pxd primer3/*.pyx primer3/*.h
+include primer3/*.pxd primer3/*.pxi primer3/*.pyx primer3/*.h
 include primer3/src/libprimer3/*.h primer3/src/libprimer3/*.c
 include primer3/src/libprimer3/klib/khash.h
 include primer3/src/libprimer3/klib/README.md

--- a/docs/cython_help.md
+++ b/docs/cython_help.md
@@ -40,4 +40,8 @@ and to build/install using a standard `setup.py` add the lines (fill in the ...s
         ...)
 ```
 
-and it should work
+and it should work.
+
+## Notes
+- Many `_ThermoAnalysis` methods (e.g. `calc_heterodimer_c`) have C string argument
+`c_ascii_structure` to enable 3rd party use for structures reuse

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -26,7 +26,7 @@ import os
 from typing import List
 
 # Per PEP-440 https://peps.python.org/pep-0440/#public-version-identifiers
-__version__ = '2.0.0a1'
+__version__ = '2.0.0'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
     'Copyright 2014-2023, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -26,7 +26,7 @@ import os
 from typing import List
 
 # Per PEP-440 https://peps.python.org/pep-0440/#public-version-identifiers
-__version__ = '1.2.2'
+__version__ = '2.0.0a1'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
     'Copyright 2014-2023, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'

--- a/primer3/src/libprimer3/libprimer3.c
+++ b/primer3/src/libprimer3/libprimer3.c
@@ -5283,8 +5283,7 @@ recalc_secundary_structures(
     num_print = retval->best_pairs.num_pairs;
     for (int i = 0 ; i < num_print ; i++) {
       recalc_primer_sec_struct(
-        retval->best_pairs.pairs[i].
-        left,
+        retval->best_pairs.pairs[i].left,
         0,
         pa,
         sa,
@@ -5381,6 +5380,10 @@ recalc_primer_sec_struct(
 
   if (pa->thermodynamic_oligo_alignment==0) {
     dpal_results any, end;
+    /* NOTE: important to set these values to NULL to prevent segfaults */
+    any.sec_struct = NULL;
+    end.sec_struct = NULL;
+
     if (p_rec->self_any > 0.0) {
       dpal((const unsigned char *) s1, (const unsigned char *) s1_rev,
            dpal_arg_to_use->local, DPM_STRUCT, &any);
@@ -5397,6 +5400,11 @@ recalc_primer_sec_struct(
   /* Thermodynamic approach, fwd-primer */
   if (pa->thermodynamic_oligo_alignment==1) {
     thal_results any, end, hair;
+    /* NOTE: important to set these values to NULL to prevent segfaults */
+    any.sec_struct = NULL;
+    end.sec_struct = NULL;
+    hair.sec_struct = NULL;
+
     if (p_rec->self_any > 0.0 ) {
       thal(
         (const unsigned char *) s1,

--- a/primer3/src/libprimer3/libprimer3flex.c
+++ b/primer3/src/libprimer3/libprimer3flex.c
@@ -6182,8 +6182,7 @@ recalc_secundary_structures(
     num_print = retval->best_pairs.num_pairs;
     for (int i = 0 ; i < num_print ; i++) {
       recalc_primer_sec_struct(
-        retval->best_pairs.pairs[i].
-        left,
+        retval->best_pairs.pairs[i].left,
         0,
         pa,
         sa,
@@ -6232,7 +6231,7 @@ recalc_primer_sec_struct(
   char s1[THAL_MAX_ALIGN+1], s1_rev[THAL_MAX_ALIGN+1];
   int overhang_len;
   /* s1 is the forward oligo. */
-  if (primer_type == 0) {  /*left */
+  if (primer_type == 0) {  /* left */
     if (NULL != sa->overhang_left) {
       overhang_len = strlen(sa->overhang_left);
       strcpy(s1, sa->overhang_left);
@@ -6287,9 +6286,11 @@ recalc_primer_sec_struct(
     }
     p3_reverse_complement(s1_rev, s1);
   }
-
   if (pa->thermodynamic_oligo_alignment==0) {
     dpal_results any, end;
+    /* NOTE: important to set these values to NULL to prevent segfaults */
+    any.sec_struct = NULL;
+    end.sec_struct = NULL;
     if (p_rec->self_any > 0.0) {
       dpal(
         (const unsigned char*) s1,
@@ -6322,6 +6323,11 @@ recalc_primer_sec_struct(
   /* Thermodynamic approach, fwd-primer */
   if (pa->thermodynamic_oligo_alignment==1) {
     thal_results any, end, hair;
+    /* NOTE: important to set these values to NULL to prevent segfaults */
+    any.sec_struct = NULL;
+    end.sec_struct = NULL;
+    hair.sec_struct = NULL;
+
     if (p_rec->self_any > 0.0 ) {
       thal(
         (const unsigned char*) s1,

--- a/primer3/src/libprimer3/thal.c
+++ b/primer3/src/libprimer3/thal.c
@@ -496,7 +496,7 @@ thal(const unsigned char *oligo_f,
      const thal_args *a,
      const thal_mode mode,
      thal_results *o,
-     const int print_output)  /* primer3-py modification argumen */
+     const int print_output)  /* primer3-py modification argument */
 {
   double* SH;
   int i, j;

--- a/primer3/src/libprimer3/thal.c
+++ b/primer3/src/libprimer3/thal.c
@@ -680,6 +680,7 @@ thal(const unsigned char *oligo_f,
         if (print_output == 1) { /* primer3-py update to supress undesired printing */
           fputs("No secondary structure could be calculated\n", stderr);
         }
+        o->no_structure = 1;
     }
 
     if(o->temp == -_INFINITY && (!strcmp(o->msg, ""))) { o->temp=0.0; }

--- a/primer3/src/libprimer3/thalflex.c
+++ b/primer3/src/libprimer3/thalflex.c
@@ -652,6 +652,7 @@ thal(
         if (print_output == 1) { /* primer3-py update to supress undesired printing */
           fputs("No secondary structure could be calculated\n", stderr);
         }
+        o->no_structure = 1;
     }
 
     if(o->temp == -_INFINITY && (!strcmp(o->msg, ""))) { o->temp=0.0; }

--- a/primer3/thermoanalysis.pxd
+++ b/primer3/thermoanalysis.pxd
@@ -23,584 +23,45 @@ Cython header file for thermoanalysis.pyx -- allows for cross-project Cython /
 C integration of the low-level thermodynamic analysis bindings.
 
 '''
-from libc.float cimport DBL_MAX
-from libc.stdio cimport FILE
-from libc.stdlib cimport free
-from libc.string cimport strlen
-
-
-cdef extern from "thal.h":
-    ctypedef enum thal_alignment_type:
-        thal_any = 1,
-        thal_end1 = 2,
-        thal_end2 = 3,
-        thal_hairpin = 4
-
-    ctypedef struct thal_args:
-        # int debug                 # if non zero, print debugging info to stderr
-        thal_alignment_type type  # type of thermodynamic alignment
-        int maxLoop               # maximum size of loop to consider in calcs
-        double mv                 # [ ] of monovalent cations (mM)
-        double dv                 # [ ] of divalent cations (mM)
-        double dntp               # [ ] of dNTPs (mM)
-        double dna_conc           # [ ] of oligos (nM)
-        double temp               # temp at which hairpins will be calculated
-        # int temponly              # print only temp to stderr
-        int dimer                 # if non-zero dimer structure is calculated
-
-    ctypedef struct thal_results:
-        char msg[255]
-        int no_structure # Added no structure (1 if no structure found)
-        double temp
-        double ds # Added entropy value
-        double dh # Added enthalpy value
-        double dg # Added gibbs free energy value
-        int align_end_1
-        int align_end_2
-        char* sec_struct
-
-    ctypedef enum thal_mode:
-        THL_FAST    = 0,    # this is temp only AKA thal_only
-        THL_GENERAL = 1,    # this is general
-        THL_DEBUG_F = 2,    # this is temp only  AKA thal_only
-        THL_DEBUG   = 3,
-        THL_STRUCT  = 4
-
-    ctypedef struct thal_parameters:
-        char* dangle_dh
-        char* dangle_ds
-        char* loops_dh
-        char* loops_ds
-        char* stack_dh
-        char* stack_ds
-        char* stackmm_dh
-        char* stackmm_ds
-        char* tetraloop_dh
-        char* tetraloop_ds
-        char* triloop_dh
-        char* triloop_ds
-        char* tstack_tm_inf_ds
-        char* tstack_dh
-        char* tstack2_dh
-        char* tstack2_ds
-
-    int thal_set_null_parameters(thal_parameters *a)
-    int thal_load_parameters(const char *path, thal_parameters *a, thal_results* o)
-    int thal_free_parameters(thal_parameters *a)
-    int get_thermodynamic_values(const thal_parameters *tp, thal_results *o)
-    void destroy_thal_structures()
-
-    void thal(
-        const unsigned char*,
-        const unsigned char*,
-        const thal_args*,
-        const thal_mode,
-        thal_results*,
-        const int,
-        # char*,
-    ) nogil
-
-
-cdef extern from "oligotm.h":
-    ctypedef enum tm_method_type:
-        breslauer_auto      = 0,
-        santalucia_auto     = 1
-
-    ctypedef enum salt_correction_type:
-        schildkraut    = 0,
-        santalucia     = 1,
-        owczarzy       = 2
-
-    ctypedef struct tm_ret:
-        double Tm
-        double bound
-
-    tm_ret seqtm(
-            const char* seq,        # The sequence
-            double dna_conc,        # DNA concentration (nanomolar).
-            double salt_conc,       # Concentration of divalent cations (millimolar).
-            double divalent_conc,   # Concentration of divalent cations (millimolar)
-            double dntp_conc,       # Concentration of dNTPs (millimolar)
-            double dmso_conc,       # Concentration of DMSO (%) default 0
-            double dmso_fact,       # DMSO correction factor, default 0.6
-            double formamide_conc,  # Concentration of formamide (mol/l)
-            int    nn_max_len,      # The maximum sequence length for nn model
-            tm_method_type  tm_method,              # See description above.
-            salt_correction_type salt_corrections,  # See description above.
-            double annealing_temp  # Actual annealing temperature of the PCR reaction
-    ) nogil
-
-    int set_default_thal_parameters(thal_parameters *a)
-
-
-cdef extern from "p3_seq_lib.h":
-    ctypedef struct pr_append_str:
-        int storage_size
-        char* data
-
-    ctypedef struct seq_lib:
-        pass
-
-    seq_lib* create_empty_seq_lib()
-
-    int seq_lib_num_seq(const seq_lib* lib)
-
-    void destroy_seq_lib(seq_lib *lib)
-    int add_seq_to_seq_lib(seq_lib *, char *, char *, const char *)
-    void reverse_complement_seq_lib(seq_lib  *lib)
-
-
-cdef extern from "masker.h":
-    ctypedef enum masking_direction:
-        both_on_same = 0,
-        both_separately = 1,
-        fwd = 2,
-        rev = 3
-
-    ctypedef struct formula_parameters:
-        # If the list is created with GenomeTester4,
-        # 210 char should be enough to contain the full list name
-        char list_file_name[210]
-        unsigned int oligo_length
-
-        # binary mask is used for cutting the k-mer into the size of oligo_length
-        unsigned long long binary_mask
-
-        # number of unique k-mers in the given k-mer list
-        unsigned long long words_in_list
-
-        # pointer to k-mer list
-        const char* word_list
-        const char* pointer
-        size_t size
-
-        # coefficients for all possible masking formula variables (and their squares)
-        # concerning this k-mer list.
-        # If certain variables are not used, their coefficiest are equal to 0
-        double mm0
-        double mm1
-        double mm2
-        double mm0_2
-        double mm1_2
-        double mm2_2
-
-    ctypedef struct masker_parameters:
-        # strand to mask
-        masking_direction mdir
-
-        # primer failure rate cutoff used in primer design,
-        # potential locations in a sequence for primers with PCR
-        # failure rate over the given cutoff are masked
-        # see function calculate_scores() from masker.c
-        double failure_rate
-
-        # absolute value cutoff, this can be used for masking all the k-mers in a sequence
-        # that have the frequency over abs_cutoff in a k-mer list
-        unsigned int abs_cutoff
-
-        # number of nucleotides masked in 5' and 3' direction with respect
-        # to the 3' end of a primer
-        int nucl_masked_in_5p_direction
-        int nucl_masked_in_3p_direction
-
-        # If masker is used as a separate application then always print_sequence=1,
-        # i.e the output is sent to stdout.
-        # If print_sequence=0 the output is written in a string variable and can be forwarded
-        # to the next function
-        int print_sequence
-
-        # if do_soft_masking=1, masked nucleotides and converted to lower-case, else
-        # masked nucleotide are converted to masking_char ('N' by default)
-        int do_soft_masking
-        char masking_char
-
-        # size of the masking window
-        int window_size
-
-        # number of k-mer lists used in the masking formula
-        unsigned int nlists
-        # k-mer lists and all their parameters which are used in the masking formula
-        char* list_prefix
-        formula_parameters** fp
-        double formula_intercept
-
-    formula_parameters** create_default_formula_parameters (const char *, const char*, pr_append_str*)
-    void delete_formula_parameters (formula_parameters** fp, unsigned int nlists)
-
-
-cdef extern from "libprimer3.h":
-    # Enum to define tasks primer3 can do
-    ctypedef enum task:
-        pick_pcr_primers               = 0,
-        pick_pcr_primers_and_hyb_probe = 1,
-        pick_left_only                 = 2,
-        pick_right_only                = 3,
-        pick_hyb_probe_only            = 4,
-        generic_p3                     = 5,
-        pick_cloning_primers           = 6,
-        pick_discriminative_primers    = 7,
-        pick_sequencing_primers        = 8,
-        pick_primer_list               = 9,
-        check_primers                  = 10
-
-    cdef struct args_for_one_oligo_or_primer:
-        seq_lib* repeat_lib
-        int max_poly_x
-
-    ctypedef struct p3_global_settings:
-        task   primer_task
-        args_for_one_oligo_or_primer p_args
-        args_for_one_oligo_or_primer o_args
-        int    pick_left_primer
-        int    pick_right_primer
-        int    pick_internal_oligo
-        double product_max_tm
-        double product_min_tm
-        int show_secondary_structure_alignment
-        int thermodynamic_oligo_alignment
-        int thermodynamic_template_alignment
-        double annealing_temp
-        salt_correction_type salt_corrections
-        int first_base_index
-        int num_return
-        int pick_anyway
-        double inside_penalty
-        double outside_penalty
-
-        int lowercase_masking
-        int mask_template
-        int masking_parameters_changed
-        # Turn on masking of the trimmed_orig_seq (added by M. Lepamets)*/
-        masker_parameters mp
-
-
-    ctypedef struct interval_array_t2:
-        pass
-
-    ctypedef struct interval_array_t4:
-        pass
-
-    ctypedef struct seq_args_t:
-        interval_array_t2 tar2  # The targets.  tar2->pairs[i][0] is the start
-                                #  of the ith target, tar2->pairs[i][1] its length.
-
-        interval_array_t2 excl2  # The number of excluded regions.
-
-        interval_array_t2 excl_internal2    # Number of excluded regions for
-                                            # internaloligo; similar to excl2.
-
-        interval_array_t4 ok_regions
-
-        # List of overlap junction positions.
-        int primer_overlap_junctions[200]
-
-        int primer_overlap_junctions_count
-
-        # List of overlap junction positions.
-        int intl_overlap_junctions[200]
-
-
-        int intl_overlap_junctions_count
-
-        int incl_s  # The 0-based start of included region.
-        int incl_l  # The length of the included region, which is also the
-                    # length of the trimmed_seq field.
-
-        int  start_codon_pos    # Index of first base of the start codon.
-        char start_codon_seq[4] # Sequence of the start codon, usually ATG\0
-
-        int  *quality       # Vector of quality scores.
-        int  n_quality      # Number of valid elements in 'quality'
-        int  quality_storage_size   # Amount of storage quality points to.
-
-        char *sequence      # The template sequence itself as input,  not
-                            # trimmed, not up-cased.
-        char *sequence_name # An identifier for the sequence.
-        char *sequence_file # Another identifier for the sequence.
-        char *trimmed_seq   # The included region only, _UPCASED_.
-
-        # Element add by T. Koressaar support lowercase masking:
-        char *trimmed_orig_seq  # Trimmed version of the original, mixed-case sequence.
-        char *trimmed_masked_seq    # Masked version of the trimmed seq
-        char *trimmed_masked_seq_r  # Masked version of the other strand of the trimmed seq
-
-        char *upcased_seq   # Upper case version of sequence (_not_ trimmed).
-
-        char *upcased_seq_r # Upper case version of sequence, other strand (_not_ trimmed).
-
-        char *left_input    # A left primer to check or design around.
-
-        char *right_input   # A right primer to check or design around.
-
-        char *internal_input    # An internal oligo to check or design around.
-
-        int force_left_start    # The 0-based forced 5' start left primer.
-        int force_left_end  # The 0-based forced 3' end left primer.
-        int force_right_start   # The 0-based forced 5' start right primer.
-        int force_right_end # The 0-based forced 3' end right primer.
-        char *overhang_left # sequence added to the 5' end of the left primer
-        char *overhang_right    # sequence added to the 5' end of the right primer
-        char *overhang_right_rv # the reverse complement of *overhang_right matching the sequence
-
-    ctypedef struct rep_sim:
-        char *name  # Name of the sequence format with maximum similarity to the oligo.
-
-        short min   # The minimum score in slot 'score' (below).
-                    # (Used when the objective function involves
-                    # minimization of mispriming possibilities.)
-
-        short max   # The index of the maximum score in slot 'score' (below).
-
-        double *score   # Array of similarity (i.e. false-priming) scores,
-                        # one for each entry in the 'repeat_lib' slot
-                        # of the primargs struct.  In libprimer3.c,
-                        # score is set to NULL to indicate that
-                        # the rep_sim structure is uninitialized.
-
-    ctypedef struct oligo_problems:
-        unsigned long int prob
-
-    ctypedef struct primer_rec:
-        rep_sim repeat_sim
-        # Information on the best repeat library (mispriming library)
-        # match for this oligo (primer), plus additional scores.
-
-        double temp # The oligo melting temperature calculated for the primer.
-
-        double bound   # The fraction of primers bound at melting temperature temperature.
-
-        double gc_content
-
-        # Penalty for distance from "ideal" position as specified
-        # by inside_penalty and outside_penalty.
-        double position_penalty
-
-        double quality # Part of objective function due to this primer.
-
-        double end_stability
-        # Delta G of disription of 5 3' bases
-
-        int    start    # Position of the 5'-most base within the primer
-                        # WITH RESPECT TO THE seq_args FIELD
-                        # trimmed_seq.
-
-        int    seq_quality      # Minimum quality score of bases included.
-        int    seq_end_quality  # Minimum quality core of the 5 3' bases.
-
-        double self_any     # Self complementarity as local alignment * 100.
-
-        double self_end     # Self complementarity at 3' end * 100
-
-        double hairpin_th   # hairpin, thermodynamical approach and calculated as any
-
-        #  Max 3' complementarity to any ectopic site in template
-        # on the given template strand.
-        double template_mispriming
-
-        # Max 3' complementarity to any ectopic site in the
-        # template on the reverse complement of the given template strand.
-        double template_mispriming_r
-
-        char* self_any_struct# Secondary structure of self_any
-
-        char* self_end_struct  # Secondary structure of self_end
-
-        char* hairpin_struct  # Secondary structure of hairpin_th
-
-        char* template_mispriming_struct  # Secondary structure of template_mispriming
-
-        char* template_mispriming_r_struct  # Secondary structure of template_mispriming_r
-
-        char   length  # Length of the oligo.
-        char   num_ns  # Number of Ns in the oligo.
-
-        char   must_use  # Non-0 if the oligo must be used even if it is illegal.
-        char   overlaps  # Non-0 if the oligo overlaps some oligo used in one of the best pairs.
-
-        oligo_problems problems
-        char   overlaps_overlap_position
-
-        char template_mispriming_ok  # Non-0 if the oligo was checked for this already and it is ok.
-
-        double failure_rate  # Primer failure rate due to non-specific priming
-
-    # oligo_array is used to store a list of oligos or primers
-    ctypedef struct oligo_array:
-        # Array of oligo (primer) records.
-        primer_rec* oligo
-        # Number of initialized elements
-        int num_elem
-        # Storage lengths of oligo
-        int storage_size
-
-        # # Type of oligos in the array
-        # oligo_type type
-        # # Primers statistics.
-        # oligo_stats expl
-
-    ctypedef struct primer_pair:
-        double pair_quality  # Penalty value of the primer pair */
-
-        double diff_tm       # Absolute value of the difference between melting temperatures for left and right primers.
-
-        double product_tm    # Estimated melting temperature of the product. */
-
-        double product_tm_oligo_tm_diff # Difference in Tm between the primer with lowest Tm the product Tm. */
-
-        double t_opt_a
-
-        double compl_any  # Local complementarity score between left and right primers (* 100).
-
-        double compl_end  # 3'-anchored global complementatory score between left and right primers (* 100).
-
-        double template_mispriming # Maximum total mispriming score of both primers to ectopic sites in the template, on "same" strand (* 100). */
-
-        char *compl_any_struct # Secondary structure of compl_any */
-
-        char *compl_end_struct # Secondary structure of compl_end */
-
-        char *template_mispriming_struct # Secondary structure of template_mispriming */
-
-        double repeat_sim    # Maximum total similarity of both primers to the sequence from given file in fasta format.
-
-        primer_rec* left     # Left primer.
-        primer_rec* right    # Right primer.
-        primer_rec* intl     # Internal oligo.
-
-        char   must_use
-
-        int    product_size    # product size.
-        int    target   # 1 if there is a target between the right and left primers.
-        char   *rep_name
-
-    ctypedef struct pair_array_t:
-        pass
-        int         storage_size
-        int         num_pairs
-        primer_pair *pairs
-        # pair_stats  expl
-
-    # Enum explaining if output are pairs
-    ctypedef enum p3_output_type:
-        primer_pairs    = 0,
-        primer_list     = 1
-
-    ctypedef struct p3retval:
-        oligo_array fwd
-        oligo_array intl
-        oligo_array rev
-
-        # Array of best primer pairs
-        pair_array_t best_pairs
-
-        # Enum to store type of output
-        p3_output_type output_type
-
-        # Place for error messages
-        pr_append_str glob_err
-        pr_append_str per_sequence_err
-        pr_append_str warnings
-
-        # An optional _output_, meaninful if a
-        # start_codon_pos is "not null".  The position of
-        # the intial base of the leftmost stop codon that
-        # is to the right of sa->start_codon_pos.
-        int stop_codon_pos
-
-        int upstream_stop_codon    # TO DO needs docs
-
-
-    void init_pr_append_str(pr_append_str *s)
-    const pair_array_t* p3_get_rv_best_pairs(const p3retval *r)
-    const oligo_array* p3_get_rv_fwd(const p3retval *r)
-    const oligo_array* p3_get_rv_intl(const p3retval *r)
-    const oligo_array* p3_get_rv_rev(const p3retval *r)
-
-    const char *p3_get_pair_array_explain_string(const pair_array_t*)
-    const char *p3_get_oligo_array_explain_string(const oligo_array*)
-
-    int PR_START_CODON_POS_IS_NULL(seq_args_t* sa)
-
-    void p3_destroy_global_settings(p3_global_settings*)
-    p3_global_settings* p3_create_global_settings()
-    void p3_print_args(const p3_global_settings*, seq_args_t*)
-
-    void destroy_secundary_structures(const p3_global_settings *pa, p3retval *retval)
-    void destroy_p3retval(p3retval *)
-    void destroy_dpal_thal_arg_holder()
-
-    char* p3_get_rv_and_gs_warnings(const p3retval *retval, const p3_global_settings *pa)
-
-    pr_append_str *create_pr_append_str()
-    int pr_append_new_chunk_external(pr_append_str *, const char *)
-    int pr_is_empty(const pr_append_str *)
-    const char* pr_append_str_chars(const pr_append_str *x)
-    void destroy_pr_append_str(pr_append_str *)
-    void destroy_pr_append_str_data(pr_append_str *str)
-
-    seq_args_t* create_seq_arg()
-    void destroy_seq_args(seq_args_t*)
-
-    int p3_ol_has_any_problem(const primer_rec *oligo)
-    const char* p3_get_ol_problem_string(const primer_rec *oligo)
-
-    char  *pr_oligo_sequence(const seq_args_t*, const primer_rec*)
-    char  *pr_oligo_overhang_sequence(const seq_args_t*, const primer_rec*)
-
-    char  *pr_oligo_rev_c_sequence(const seq_args_t*, const primer_rec*)
-    char  *pr_oligo_rev_c_overhang_sequence(const seq_args_t*, const primer_rec*)
-
-    double oligo_max_template_mispriming(const primer_rec*)
-    double oligo_max_template_mispriming_thermod(const primer_rec*)
-    char* oligo_max_template_mispriming_struct(const primer_rec* h)
-
-    p3retval* choose_primers(
-        const p3_global_settings*,
-        seq_args_t*
-    )
-
-cdef:
-    double ALIGN_SCORE_UNDEF = -DBL_MAX
-    double PR_DEFAULT_PRODUCT_MAX_TM = 1000000.0
-    double PR_DEFAULT_PRODUCT_MIN_TM = -1000000.0
-    double PR_INFINITE_POSITION_PENALTY = -1.0
-    double PR_DEFAULT_INSIDE_PENALTY = PR_INFINITE_POSITION_PENALTY
-    double PR_DEFAULT_OUTSIDE_PENALTY = 0.0
-
-cdef extern from "read_boulder.h":
-    ctypedef struct read_boulder_record_results:
-        int explain_flag
-        int file_flag
-
-    ctypedef enum p3_file_type:
-        all_parameters    = 0,
-        sequence          = 1,
-        settings          = 2
-
-    int read_boulder_record(
-        FILE *file_input,
-        const int *strict_tags,
-        const int * io_version,
-        int echo_output,
-        const p3_file_type read_file_type,
-        p3_global_settings *pa,
-        seq_args_t*sarg,
-        pr_append_str *fatal_err,
-        pr_append_str *nonfatal_err,
-        pr_append_str *warnings,
-        read_boulder_record_results *,
-        char*
-    )
+# NOTE: `cdef extern from 'thal.h'` is not used here to prevent API
+# contamination.  Shadow structs are used instead.
+
+# Shadow struct for primer3 `thal.h` `thal_args`
+ctypedef struct p3_thal_args_t:
+    # int debug                 # if non zero, print debugging info to stderr
+    int type  # type of thermodynamic alignment
+    int maxLoop               # maximum size of loop to consider in calcs
+    double mv                 # [ ] of monovalent cations (mM)
+    double dv                 # [ ] of divalent cations (mM)
+    double dntp               # [ ] of dNTPs (mM)
+    double dna_conc           # [ ] of oligos (nM)
+    double temp               # temp at which hairpins will be calculated
+    # int temponly              # print only temp to stderr
+    int dimer                 # if non-zero dimer structure is calculated
+
+
+# Shadow struct for primer3 `thal.h` `thal_results`
+ctypedef struct p3_thal_results_t:
+    char msg[255]
+    int no_structure # Added no structure (1 if no structure found)
+    double temp
+    double ds # Added entropy value
+    double dh # Added enthalpy value
+    double dg # Added gibbs free energy value
+    int align_end_1
+    int align_end_2
+    char* sec_struct
 
 
 cdef class ThermoResult:
-    cdef thal_results thalres
-    cdef public object ascii_structure
+    cdef:
+        p3_thal_results_t thalres
+        public object ascii_structure
 
 
 cdef class _ThermoAnalysis:
     cdef:
-        thal_args thalargs
+        p3_thal_args_t thalargs
         int eval_mode
         public int max_nn_length
         public int _tm_method
@@ -614,26 +75,33 @@ cdef class _ThermoAnalysis:
         public float formamide_conc
         public float annealing_temp_c
 
-        p3_global_settings* global_settings_data
-        seq_args_t* sequence_args_data
+        # NOTE: these two attributes are void* pointers remove the need for
+        # `cdef extern from 'libprimer3.h'` in this file.
+        # p3_global_settings* global_settings_data
+        void* global_settings_data
+        # seq_args_t* sequence_args_data
+        void* sequence_args_data
 
     cdef inline ThermoResult calc_heterodimer_c(
             _ThermoAnalysis self,
             unsigned char* s1,
             unsigned char* s2,
-            bint output_structure
+            bint output_structure,
+            char* c_ascii_structure,
     )
 
     cdef inline ThermoResult calc_homodimer_c(
             _ThermoAnalysis self,
             unsigned char* s1,
-            bint output_structure
+            bint output_structure,
+            char* c_ascii_structure,
     )
 
     cdef inline ThermoResult calc_hairpin_c(
             _ThermoAnalysis self,
             unsigned char* s1,
-            bint output_structure
+            bint output_structure,
+            char* c_ascii_structure,
     )
 
     cdef inline ThermoResult calc_end_stability_c(
@@ -642,7 +110,10 @@ cdef class _ThermoAnalysis:
             unsigned char* s2,
     )
 
-    cdef inline double calc_tm_c(_ThermoAnalysis self, char* s1)
+    cdef inline double calc_tm_c(
+            _ThermoAnalysis self,
+            char* s1
+    )
 
     cpdef ThermoResult calc_heterodimer(
             _ThermoAnalysis self,
@@ -668,20 +139,4 @@ cdef class _ThermoAnalysis:
             object putative_seq,
             object sequences,
             double tm_threshold,
-    )
-
-cdef:
-    int pdh_wrap_set_seq_args_globals(
-        p3_global_settings* global_settings_data,
-        seq_args_t* sequence_args_data,
-        object kmer_lists_path,
-        char* in_buffer,
-    ) except -1
-
-    seq_lib* pdh_create_seq_lib(object seq_dict) except NULL
-
-    object pdh_design_output_to_dict(
-        const p3_global_settings* global_settings_data,
-        const seq_args_t* sequence_args_data,
-        const p3retval *retval,
     )

--- a/primer3/thermoanalysis.pxi
+++ b/primer3/thermoanalysis.pxi
@@ -1,0 +1,593 @@
+# cython: language_level=3
+# Copyright (C) 2014-2020. Ben Pruitt & Nick Conway; Wyss Institute
+# See LICENSE for full GPLv2 license.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+'''
+thermoanalysis.pxi
+~~~~~~~~~~~~~~~~~~
+
+Cython INCLUDE file for thermoanalysis.pyx
+
+'''
+
+from libc.float cimport DBL_MAX
+from libc.stdio cimport FILE
+from libc.stdlib cimport free
+from libc.string cimport strlen
+
+
+cdef extern from "thal.h":
+    ctypedef enum thal_alignment_type:
+        thal_any = 1,
+        thal_end1 = 2,
+        thal_end2 = 3,
+        thal_hairpin = 4
+
+    ctypedef struct thal_args:
+        # int debug                 # if non zero, print debugging info to stderr
+        thal_alignment_type type  # type of thermodynamic alignment
+        int maxLoop               # maximum size of loop to consider in calcs
+        double mv                 # [ ] of monovalent cations (mM)
+        double dv                 # [ ] of divalent cations (mM)
+        double dntp               # [ ] of dNTPs (mM)
+        double dna_conc           # [ ] of oligos (nM)
+        double temp               # temp at which hairpins will be calculated
+        # int temponly              # print only temp to stderr
+        int dimer                 # if non-zero dimer structure is calculated
+
+    ctypedef struct thal_results:
+        char msg[255]
+        int no_structure # Added no structure (1 if no structure found)
+        double temp
+        double ds # Added entropy value
+        double dh # Added enthalpy value
+        double dg # Added gibbs free energy value
+        int align_end_1
+        int align_end_2
+        char* sec_struct
+
+    ctypedef enum thal_mode:
+        THL_FAST    = 0,    # this is temp only AKA thal_only
+        THL_GENERAL = 1,    # this is general
+        THL_DEBUG_F = 2,    # this is temp only  AKA thal_only
+        THL_DEBUG   = 3,
+        THL_STRUCT  = 4
+
+    ctypedef struct thal_parameters:
+        char* dangle_dh
+        char* dangle_ds
+        char* loops_dh
+        char* loops_ds
+        char* stack_dh
+        char* stack_ds
+        char* stackmm_dh
+        char* stackmm_ds
+        char* tetraloop_dh
+        char* tetraloop_ds
+        char* triloop_dh
+        char* triloop_ds
+        char* tstack_tm_inf_ds
+        char* tstack_dh
+        char* tstack2_dh
+        char* tstack2_ds
+
+    int thal_set_null_parameters(thal_parameters *a)
+    int thal_load_parameters(const char *path, thal_parameters *a, thal_results* o)
+    int thal_free_parameters(thal_parameters *a)
+    int get_thermodynamic_values(const thal_parameters *tp, thal_results *o)
+    void destroy_thal_structures()
+
+    void thal(
+        const unsigned char*,
+        const unsigned char*,
+        const thal_args*,
+        const thal_mode,
+        thal_results*,
+        const int,
+        # char*,
+    ) nogil
+
+
+cdef extern from "oligotm.h":
+    ctypedef enum tm_method_type:
+        breslauer_auto      = 0,
+        santalucia_auto     = 1
+
+    ctypedef enum salt_correction_type:
+        schildkraut    = 0,
+        santalucia     = 1,
+        owczarzy       = 2
+
+    ctypedef struct tm_ret:
+        double Tm
+        double bound
+
+    tm_ret seqtm(
+            const char* seq,        # The sequence
+            double dna_conc,        # DNA concentration (nanomolar).
+            double salt_conc,       # Concentration of divalent cations (millimolar).
+            double divalent_conc,   # Concentration of divalent cations (millimolar)
+            double dntp_conc,       # Concentration of dNTPs (millimolar)
+            double dmso_conc,       # Concentration of DMSO (%) default 0
+            double dmso_fact,       # DMSO correction factor, default 0.6
+            double formamide_conc,  # Concentration of formamide (mol/l)
+            int    nn_max_len,      # The maximum sequence length for nn model
+            tm_method_type  tm_method,              # See description above.
+            salt_correction_type salt_corrections,  # See description above.
+            double annealing_temp  # Actual annealing temperature of the PCR reaction
+    ) nogil
+
+    int set_default_thal_parameters(thal_parameters *a)
+
+
+cdef extern from "p3_seq_lib.h":
+    ctypedef struct pr_append_str:
+        int storage_size
+        char* data
+
+    ctypedef struct seq_lib:
+        pass
+
+    seq_lib* create_empty_seq_lib()
+
+    int seq_lib_num_seq(const seq_lib* lib)
+
+    void destroy_seq_lib(seq_lib *lib)
+    int add_seq_to_seq_lib(seq_lib *, char *, char *, const char *)
+    void reverse_complement_seq_lib(seq_lib  *lib)
+
+
+cdef extern from "masker.h":
+    ctypedef enum masking_direction:
+        both_on_same = 0,
+        both_separately = 1,
+        fwd = 2,
+        rev = 3
+
+    ctypedef struct formula_parameters:
+        # If the list is created with GenomeTester4,
+        # 210 char should be enough to contain the full list name
+        char list_file_name[210]
+        unsigned int oligo_length
+
+        # binary mask is used for cutting the k-mer into the size of oligo_length
+        unsigned long long binary_mask
+
+        # number of unique k-mers in the given k-mer list
+        unsigned long long words_in_list
+
+        # pointer to k-mer list
+        const char* word_list
+        const char* pointer
+        size_t size
+
+        # coefficients for all possible masking formula variables (and their squares)
+        # concerning this k-mer list.
+        # If certain variables are not used, their coefficiest are equal to 0
+        double mm0
+        double mm1
+        double mm2
+        double mm0_2
+        double mm1_2
+        double mm2_2
+
+    ctypedef struct masker_parameters:
+        # strand to mask
+        masking_direction mdir
+
+        # primer failure rate cutoff used in primer design,
+        # potential locations in a sequence for primers with PCR
+        # failure rate over the given cutoff are masked
+        # see function calculate_scores() from masker.c
+        double failure_rate
+
+        # absolute value cutoff, this can be used for masking all the k-mers in a sequence
+        # that have the frequency over abs_cutoff in a k-mer list
+        unsigned int abs_cutoff
+
+        # number of nucleotides masked in 5' and 3' direction with respect
+        # to the 3' end of a primer
+        int nucl_masked_in_5p_direction
+        int nucl_masked_in_3p_direction
+
+        # If masker is used as a separate application then always print_sequence=1,
+        # i.e the output is sent to stdout.
+        # If print_sequence=0 the output is written in a string variable and can be forwarded
+        # to the next function
+        int print_sequence
+
+        # if do_soft_masking=1, masked nucleotides and converted to lower-case, else
+        # masked nucleotide are converted to masking_char ('N' by default)
+        int do_soft_masking
+        char masking_char
+
+        # size of the masking window
+        int window_size
+
+        # number of k-mer lists used in the masking formula
+        unsigned int nlists
+        # k-mer lists and all their parameters which are used in the masking formula
+        char* list_prefix
+        formula_parameters** fp
+        double formula_intercept
+
+    formula_parameters** create_default_formula_parameters (const char *, const char*, pr_append_str*)
+    void delete_formula_parameters (formula_parameters** fp, unsigned int nlists)
+
+
+cdef extern from "libprimer3.h":
+    # Enum to define tasks primer3 can do
+    ctypedef enum task:
+        pick_pcr_primers               = 0,
+        pick_pcr_primers_and_hyb_probe = 1,
+        pick_left_only                 = 2,
+        pick_right_only                = 3,
+        pick_hyb_probe_only            = 4,
+        generic_p3                     = 5,
+        pick_cloning_primers           = 6,
+        pick_discriminative_primers    = 7,
+        pick_sequencing_primers        = 8,
+        pick_primer_list               = 9,
+        check_primers                  = 10
+
+    cdef struct args_for_one_oligo_or_primer:
+        seq_lib* repeat_lib
+        int max_poly_x
+
+    ctypedef struct p3_global_settings:
+        task   primer_task
+        args_for_one_oligo_or_primer p_args
+        args_for_one_oligo_or_primer o_args
+        int    pick_left_primer
+        int    pick_right_primer
+        int    pick_internal_oligo
+        double product_max_tm
+        double product_min_tm
+        int show_secondary_structure_alignment
+        int thermodynamic_oligo_alignment
+        int thermodynamic_template_alignment
+        double annealing_temp
+        salt_correction_type salt_corrections
+        int first_base_index
+        int num_return
+        int pick_anyway
+        double inside_penalty
+        double outside_penalty
+
+        int lowercase_masking
+        int mask_template
+        int masking_parameters_changed
+        # Turn on masking of the trimmed_orig_seq (added by M. Lepamets)*/
+        masker_parameters mp
+
+
+    ctypedef struct interval_array_t2:
+        pass
+
+    ctypedef struct interval_array_t4:
+        pass
+
+    ctypedef struct seq_args_t:
+        interval_array_t2 tar2  # The targets.  tar2->pairs[i][0] is the start
+                                #  of the ith target, tar2->pairs[i][1] its length.
+
+        interval_array_t2 excl2  # The number of excluded regions.
+
+        interval_array_t2 excl_internal2    # Number of excluded regions for
+                                            # internaloligo; similar to excl2.
+
+        interval_array_t4 ok_regions
+
+        # List of overlap junction positions.
+        int primer_overlap_junctions[200]
+
+        int primer_overlap_junctions_count
+
+        # List of overlap junction positions.
+        int intl_overlap_junctions[200]
+
+
+        int intl_overlap_junctions_count
+
+        int incl_s  # The 0-based start of included region.
+        int incl_l  # The length of the included region, which is also the
+                    # length of the trimmed_seq field.
+
+        int  start_codon_pos    # Index of first base of the start codon.
+        char start_codon_seq[4] # Sequence of the start codon, usually ATG\0
+
+        int  *quality       # Vector of quality scores.
+        int  n_quality      # Number of valid elements in 'quality'
+        int  quality_storage_size   # Amount of storage quality points to.
+
+        char *sequence      # The template sequence itself as input,  not
+                            # trimmed, not up-cased.
+        char *sequence_name # An identifier for the sequence.
+        char *sequence_file # Another identifier for the sequence.
+        char *trimmed_seq   # The included region only, _UPCASED_.
+
+        # Element add by T. Koressaar support lowercase masking:
+        char *trimmed_orig_seq  # Trimmed version of the original, mixed-case sequence.
+        char *trimmed_masked_seq    # Masked version of the trimmed seq
+        char *trimmed_masked_seq_r  # Masked version of the other strand of the trimmed seq
+
+        char *upcased_seq   # Upper case version of sequence (_not_ trimmed).
+
+        char *upcased_seq_r # Upper case version of sequence, other strand (_not_ trimmed).
+
+        char *left_input    # A left primer to check or design around.
+
+        char *right_input   # A right primer to check or design around.
+
+        char *internal_input    # An internal oligo to check or design around.
+
+        int force_left_start    # The 0-based forced 5' start left primer.
+        int force_left_end  # The 0-based forced 3' end left primer.
+        int force_right_start   # The 0-based forced 5' start right primer.
+        int force_right_end # The 0-based forced 3' end right primer.
+        char *overhang_left # sequence added to the 5' end of the left primer
+        char *overhang_right    # sequence added to the 5' end of the right primer
+        char *overhang_right_rv # the reverse complement of *overhang_right matching the sequence
+
+    ctypedef struct rep_sim:
+        char *name  # Name of the sequence format with maximum similarity to the oligo.
+
+        short min   # The minimum score in slot 'score' (below).
+                    # (Used when the objective function involves
+                    # minimization of mispriming possibilities.)
+
+        short max   # The index of the maximum score in slot 'score' (below).
+
+        double *score   # Array of similarity (i.e. false-priming) scores,
+                        # one for each entry in the 'repeat_lib' slot
+                        # of the primargs struct.  In libprimer3.c,
+                        # score is set to NULL to indicate that
+                        # the rep_sim structure is uninitialized.
+
+    ctypedef struct oligo_problems:
+        unsigned long int prob
+
+    ctypedef struct primer_rec:
+        rep_sim repeat_sim
+        # Information on the best repeat library (mispriming library)
+        # match for this oligo (primer), plus additional scores.
+
+        double temp # The oligo melting temperature calculated for the primer.
+
+        double bound   # The fraction of primers bound at melting temperature temperature.
+
+        double gc_content
+
+        # Penalty for distance from "ideal" position as specified
+        # by inside_penalty and outside_penalty.
+        double position_penalty
+
+        double quality # Part of objective function due to this primer.
+
+        double end_stability
+        # Delta G of disription of 5 3' bases
+
+        int    start    # Position of the 5'-most base within the primer
+                        # WITH RESPECT TO THE seq_args FIELD
+                        # trimmed_seq.
+
+        int    seq_quality      # Minimum quality score of bases included.
+        int    seq_end_quality  # Minimum quality core of the 5 3' bases.
+
+        double self_any     # Self complementarity as local alignment * 100.
+
+        double self_end     # Self complementarity at 3' end * 100
+
+        double hairpin_th   # hairpin, thermodynamical approach and calculated as any
+
+        #  Max 3' complementarity to any ectopic site in template
+        # on the given template strand.
+        double template_mispriming
+
+        # Max 3' complementarity to any ectopic site in the
+        # template on the reverse complement of the given template strand.
+        double template_mispriming_r
+
+        char* self_any_struct# Secondary structure of self_any
+
+        char* self_end_struct  # Secondary structure of self_end
+
+        char* hairpin_struct  # Secondary structure of hairpin_th
+
+        char* template_mispriming_struct  # Secondary structure of template_mispriming
+
+        char* template_mispriming_r_struct  # Secondary structure of template_mispriming_r
+
+        char   length  # Length of the oligo.
+        char   num_ns  # Number of Ns in the oligo.
+
+        char   must_use  # Non-0 if the oligo must be used even if it is illegal.
+        char   overlaps  # Non-0 if the oligo overlaps some oligo used in one of the best pairs.
+
+        oligo_problems problems
+        char   overlaps_overlap_position
+
+        char template_mispriming_ok  # Non-0 if the oligo was checked for this already and it is ok.
+
+        double failure_rate  # Primer failure rate due to non-specific priming
+
+    # oligo_array is used to store a list of oligos or primers
+    ctypedef struct oligo_array:
+        # Array of oligo (primer) records.
+        primer_rec* oligo
+        # Number of initialized elements
+        int num_elem
+        # Storage lengths of oligo
+        int storage_size
+
+        # # Type of oligos in the array
+        # oligo_type type
+        # # Primers statistics.
+        # oligo_stats expl
+
+    ctypedef struct primer_pair:
+        double pair_quality  # Penalty value of the primer pair */
+
+        double diff_tm       # Absolute value of the difference between melting temperatures for left and right primers.
+
+        double product_tm    # Estimated melting temperature of the product. */
+
+        double product_tm_oligo_tm_diff # Difference in Tm between the primer with lowest Tm the product Tm. */
+
+        double t_opt_a
+
+        double compl_any  # Local complementarity score between left and right primers (* 100).
+
+        double compl_end  # 3'-anchored global complementatory score between left and right primers (* 100).
+
+        double template_mispriming # Maximum total mispriming score of both primers to ectopic sites in the template, on "same" strand (* 100). */
+
+        char *compl_any_struct # Secondary structure of compl_any */
+
+        char *compl_end_struct # Secondary structure of compl_end */
+
+        char *template_mispriming_struct # Secondary structure of template_mispriming */
+
+        double repeat_sim    # Maximum total similarity of both primers to the sequence from given file in fasta format.
+
+        primer_rec* left     # Left primer.
+        primer_rec* right    # Right primer.
+        primer_rec* intl     # Internal oligo.
+
+        char   must_use
+
+        int    product_size    # product size.
+        int    target   # 1 if there is a target between the right and left primers.
+        char   *rep_name
+
+    ctypedef struct pair_array_t:
+        pass
+        int         storage_size
+        int         num_pairs
+        primer_pair *pairs
+        # pair_stats  expl
+
+    # Enum explaining if output are pairs
+    ctypedef enum p3_output_type:
+        primer_pairs    = 0,
+        primer_list     = 1
+
+    ctypedef struct p3retval:
+        oligo_array fwd
+        oligo_array intl
+        oligo_array rev
+
+        # Array of best primer pairs
+        pair_array_t best_pairs
+
+        # Enum to store type of output
+        p3_output_type output_type
+
+        # Place for error messages
+        pr_append_str glob_err
+        pr_append_str per_sequence_err
+        pr_append_str warnings
+
+        # An optional _output_, meaninful if a
+        # start_codon_pos is "not null".  The position of
+        # the intial base of the leftmost stop codon that
+        # is to the right of sa->start_codon_pos.
+        int stop_codon_pos
+
+        int upstream_stop_codon    # TO DO needs docs
+
+
+    void init_pr_append_str(pr_append_str *s)
+    const pair_array_t* p3_get_rv_best_pairs(const p3retval *r)
+    const oligo_array* p3_get_rv_fwd(const p3retval *r)
+    const oligo_array* p3_get_rv_intl(const p3retval *r)
+    const oligo_array* p3_get_rv_rev(const p3retval *r)
+
+    const char *p3_get_pair_array_explain_string(const pair_array_t*)
+    const char *p3_get_oligo_array_explain_string(const oligo_array*)
+
+    int PR_START_CODON_POS_IS_NULL(seq_args_t* sa)
+
+    void p3_destroy_global_settings(p3_global_settings*)
+    p3_global_settings* p3_create_global_settings()
+    void p3_print_args(const p3_global_settings*, seq_args_t*)
+
+    void destroy_secundary_structures(const p3_global_settings *pa, p3retval *retval)
+    void destroy_p3retval(p3retval *)
+    void destroy_dpal_thal_arg_holder()
+
+    char* p3_get_rv_and_gs_warnings(const p3retval *retval, const p3_global_settings *pa)
+
+    pr_append_str *create_pr_append_str()
+    int pr_append_new_chunk_external(pr_append_str *, const char *)
+    int pr_is_empty(const pr_append_str *)
+    const char* pr_append_str_chars(const pr_append_str *x)
+    void destroy_pr_append_str(pr_append_str *)
+    void destroy_pr_append_str_data(pr_append_str *str)
+
+    seq_args_t* create_seq_arg()
+    void destroy_seq_args(seq_args_t*)
+
+    int p3_ol_has_any_problem(const primer_rec *oligo)
+    const char* p3_get_ol_problem_string(const primer_rec *oligo)
+
+    char  *pr_oligo_sequence(const seq_args_t*, const primer_rec*)
+    char  *pr_oligo_overhang_sequence(const seq_args_t*, const primer_rec*)
+
+    char  *pr_oligo_rev_c_sequence(const seq_args_t*, const primer_rec*)
+    char  *pr_oligo_rev_c_overhang_sequence(const seq_args_t*, const primer_rec*)
+
+    double oligo_max_template_mispriming(const primer_rec*)
+    double oligo_max_template_mispriming_thermod(const primer_rec*)
+    char* oligo_max_template_mispriming_struct(const primer_rec* h)
+
+    p3retval* choose_primers(
+        const p3_global_settings*,
+        seq_args_t*
+    )
+
+cdef:
+    double ALIGN_SCORE_UNDEF = -DBL_MAX
+    double PR_DEFAULT_PRODUCT_MAX_TM = 1000000.0
+    double PR_DEFAULT_PRODUCT_MIN_TM = -1000000.0
+    double PR_INFINITE_POSITION_PENALTY = -1.0
+    double PR_DEFAULT_INSIDE_PENALTY = PR_INFINITE_POSITION_PENALTY
+    double PR_DEFAULT_OUTSIDE_PENALTY = 0.0
+
+cdef extern from "read_boulder.h":
+    ctypedef struct read_boulder_record_results:
+        int explain_flag
+        int file_flag
+
+    ctypedef enum p3_file_type:
+        all_parameters    = 0,
+        sequence          = 1,
+        settings          = 2
+
+    int read_boulder_record(
+        FILE *file_input,
+        const int *strict_tags,
+        const int * io_version,
+        int echo_output,
+        const p3_file_type read_file_type,
+        p3_global_settings *pa,
+        seq_args_t*sarg,
+        pr_append_str *fatal_err,
+        pr_append_str *nonfatal_err,
+        pr_append_str *warnings,
+        read_boulder_record_results *,
+        char*
+    )

--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -1279,6 +1279,7 @@ cdef class _ThermoAnalysis:
             <p3_global_settings*> self.global_settings_data,
             <seq_args_t*> self.sequence_args_data,
         )
+
         if retval == NULL:
             raise ValueError('Issue choosing primers')
         try:

--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,7 @@ PACKAGE_FPS = (
     LIBPRIMER3_H_FPS +
     KLIB_H_FPS +
     ['p3helpers.pyx', 'p3helpers.h'] +
-    ['thermoanalysis.pxd', 'thermoanalysis.pyx']
+    ['thermoanalysis.pxd', 'thermoanalysis.pxi', 'thermoanalysis.pyx']
 )
 
 # ~~~~~~~~~~~~~~~~~~~~~ Primer3 C library build helpers ~~~~~~~~~~~~~~~~~~~~~ #

--- a/tests/test_primerdesign.py
+++ b/tests/test_primerdesign.py
@@ -555,6 +555,56 @@ class TestDesignBindings(unittest.TestCase):
         self.assertEqual(result['PRIMER_INTERNAL'][0]['COORDS'], [69, 24])
         self.assertEqual(len(result['PRIMER_INTERNAL']), 5)
 
+    def test_PRIMER_SECONDARY_STRUCTURE_ALIGNMENT(self):
+        '''Ensure all result pointers are initialized to NULL.
+        '''
+        seq_args = {
+            'SEQUENCE_ID': 'MH1000',
+            'SEQUENCE_TEMPLATE': (
+                'GCTTGCATGCCTGCAGGTCGACTCTAGAGGATCCCCCTACATTTT'
+                'AGCATCAGTGAGTACAGCATGCTTACTGGAAGAGAGGGTCATGCA'
+                'ACAGATTAGGAGGTAAGTTTGCAAAGGCAGGCTAAGGAGGAGACG'
+                'CACTGAATGCCATGGTAAGAACTCTGGACATAAAAATATTGGAAG'
+                'TTGTTGAGCAAGTNAAAAAAATGTTTGGAAGTGTTACTTTAGCAA'
+                'TGGCAAGAATGATAGTATGGAATAGATTGGCAGAATGAAGGCAAA'
+                'ATGATTAGACATATTGCATTAAGGTAAAAAATGATAACTGAAGAA'
+                'TTATGTGCCACACTTATTAATAAGAAAGAATATGTGAACCTTGCA'
+                'GATGTTTCCCTCTAGTAG'
+            ),
+            'SEQUENCE_INCLUDED_REGION': [36, 342],
+        }
+        global_args = {
+            'PRIMER_SECONDARY_STRUCTURE_ALIGNMENT': 1,  # key parameter for test
+            'PRIMER_OPT_SIZE': 20,
+            'PRIMER_PICK_INTERNAL_OLIGO': 1,
+            'PRIMER_INTERNAL_MAX_SELF_END': 8,
+            'PRIMER_MIN_SIZE': 18,
+            'PRIMER_MAX_SIZE': 25,
+            'PRIMER_OPT_TM': 60.0,
+            'PRIMER_MIN_TM': 57.0,
+            'PRIMER_MAX_TM': 63.0,
+            'PRIMER_MIN_GC': 20.0,
+            'PRIMER_MAX_GC': 80.0,
+            'PRIMER_MAX_POLY_X': 100,
+            'PRIMER_INTERNAL_MAX_POLY_X': 100,
+            'PRIMER_SALT_MONOVALENT': 50.0,
+            'PRIMER_DNA_CONC': 50.0,
+            'PRIMER_MAX_NS_ACCEPTED': 0,
+            'PRIMER_MAX_SELF_ANY': 12,
+            'PRIMER_MAX_SELF_END': 8,
+            'PRIMER_PAIR_MAX_COMPL_ANY': 12,
+            'PRIMER_PAIR_MAX_COMPL_END': 8,
+            'PRIMER_PRODUCT_SIZE_RANGE': [
+                [75, 100], [100, 125], [125, 150],
+                [150, 175], [175, 200], [200, 225],
+            ],
+        }
+        # This should run without a segmentation fault.
+        bindings.design_primers(
+            seq_args=seq_args,
+            global_args=global_args,
+        )
+
 
 def suite():
     suite = unittest.TestSuite()

--- a/tests/test_primerdesign.py
+++ b/tests/test_primerdesign.py
@@ -517,6 +517,7 @@ class TestDesignBindings(unittest.TestCase):
         )
         self.assertEqual(result['PRIMER_PAIR_NUM_RETURNED'], 5)
         self.assertEqual(result['PRIMER_LEFT_0'], [46, 21])
+        self.assertEqual(result['PRIMER_LEFT'][0]['COORDS'], [46, 21])
 
         bindings.design_primers(
             seq_args=seq_args,
@@ -528,8 +529,31 @@ class TestDesignBindings(unittest.TestCase):
                 'SEQ1': 'TTATGTGCCACACTTATTAATAAGAAAGAATATGTGAACCTTGCA',
             },
         )
+
+        self.assertAlmostEqual(
+            result['PRIMER_PAIR_0_PENALTY'],
+            1.37323,
+            places=4,
+        )
+        self.assertAlmostEqual(
+            result['PRIMER_PAIR'][0]['PENALTY'],
+            1.37323,
+            places=4,
+        )
+        self.assertEqual(len(result['PRIMER_PAIR']), 5)
+
         self.assertEqual(result['PRIMER_PAIR_NUM_RETURNED'], 5)
         self.assertEqual(result['PRIMER_LEFT_0'], [46, 21])
+        self.assertEqual(result['PRIMER_LEFT'][0]['COORDS'], [46, 21])
+        self.assertEqual(len(result['PRIMER_LEFT']), 5)
+
+        self.assertEqual(result['PRIMER_RIGHT_0'], [132, 20])
+        self.assertEqual(result['PRIMER_RIGHT'][0]['COORDS'], [132, 20])
+        self.assertEqual(len(result['PRIMER_RIGHT']), 5)
+
+        self.assertEqual(result['PRIMER_INTERNAL_0'], [69, 24])
+        self.assertEqual(result['PRIMER_INTERNAL'][0]['COORDS'], [69, 24])
+        self.assertEqual(len(result['PRIMER_INTERNAL']), 5)
 
 
 def suite():


### PR DESCRIPTION
- Migrated primer3 header file Cython extern imports to `thermoanalysis.pxi`
- Optional C structure string argument `c_ascii_structure` added to `_ThermoAnalysis` methods to enable 3rd party use for structures
- Version bump to 2.0.0 due to breaking change
- Fix issue whereby no_structure is not correctly 1 set to 1 when no secondary structure in found
-  add list version of `PRIMER_{PAIR, LEFT, RIGHT, INTERNAL}` to design output dictionary keys Retaining original keys as well for compatibility.
-  Fix for  missing `thal_result.sec_struct` and `dpal_results.sec_struct` initialization to `NULL` in `recalc_primer_sec_struct`