### PR TITLE
Fix ``todict`` method of ``Thermoanalysis`` and add unit test coverage

### DIFF
--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -548,7 +548,7 @@ cdef class _ThermoAnalysis:
         representation.
 
         '''
-        return self._salt_correction_method
+        return self._salt_correction_methods_int_dict[self._salt_correction_method]
 
     @salt_correction_method.setter
     def salt_correction_method(self, value: Union[int, str]):
@@ -1082,7 +1082,7 @@ cdef class _ThermoAnalysis:
             'dv_conc':      self.dv_conc,
             'dntp_conc':    self.dntp_conc,
             'dna_conc':     self.dna_conc,
-            'temp_c':       self.temp,
+            'temp_c':       self.temp_c,
             'max_loop':     self.max_loop,
             # 'temp_only':    self.temp_only,
             # 'debug':        self.thalargs.debug,

--- a/tests/test_thermoanalysis.py
+++ b/tests/test_thermoanalysis.py
@@ -34,7 +34,10 @@ try:
 except (ImportError, ModuleNotFoundError):  # For Windows compatibility
     resource = None  # type: ignore
 
-from primer3 import bindings
+from primer3 import (
+    bindings,
+    thermoanalysis,
+)
 
 from . import wrappers
 
@@ -408,6 +411,24 @@ class TestLowLevelBindings(unittest.TestCase):
                 f'calc_heterodimer > {delta_bytes_limit} bytes -- potential '
                 f'\n\t memory leak (mem increase: {em - sm})',
             )
+
+    def test_todict(self):
+        '''Unit test coverage for ``Thermoanalysis.todict``'''
+        args = {
+            'mv_conc': 51.0,
+            'dv_conc': 1.7,
+            'dntp_conc': 0.5,
+            'dna_conc': 52.0,
+            'temp_c': 36.0,
+            'max_loop': 31,
+            'max_nn_length': 61,
+            'tm_method': 'santalucia',
+            'salt_correction_method': 'santalucia',
+        }
+        ta = thermoanalysis.ThermoAnalysis(**args)
+        dict_out = ta.todict()
+        for k, v in args.items():
+            assert v == dict_out[k]
 
 
 def suite():


### PR DESCRIPTION
Addresses #122 -- fixes incorrect ``Thermoanalysis`` property reference in ``Thermoanalysis.todict``, an incidentally discovered bug w/ the `salt_correction_method` property getter, and adds `todict` coverage