### PR TITLE
Update `cibuildwheel` to latest release for python 3.12 build support

### DIFF
--- a/.github/workflows/build-wheels-pypi.yml
+++ b/.github/workflows/build-wheels-pypi.yml
@@ -37,7 +37,7 @@ jobs:
       #     platforms: 'arm64'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: "==${{ matrix.python-version }}.*"
 


### PR DESCRIPTION
Fixes build issue seen in this action pipeline: https://github.com/libnano/primer3-py/actions/runs/7845582538
Post-fix pipeline: https://github.com/libnano/primer3-py/actions/runs/7845449730