### PR TITLE
Fix `_ThermoAnalysis._set_globals_and_seq_args` for improper checks on `misprime_lib` and  `mishyb_lib`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 2.0.3 (February 15, 2024)
+
+- Fix `_ThermoAnalysis._set_globals_and_seq_args` for improper checks on `misprime_lib` and
+`mishyb_lib` leading to incorrect initialization of `mp_lib` and `mh_lib`. See issue #133
+
 ## Version 2.0.2 (February 9, 2024)
 
 - Support for python 3.12 (build, test, docs)

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -26,10 +26,10 @@ import os
 from typing import List
 
 # Per PEP-440 https://peps.python.org/pep-0440/#public-version-identifiers
-__version__ = '2.0.2'
+__version__ = '2.0.3'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
-    'Copyright 2014-2023, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'
+    'Copyright 2014-2024, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'
 )
 __license__ = 'GPLv2'
 DESCRIPTION = 'Python bindings for Primer3'

--- a/primer3/src/libprimer3/libprimer3flex.c
+++ b/primer3/src/libprimer3/libprimer3flex.c
@@ -300,6 +300,9 @@ pr_set_default_global_args_1(
   memset(a, 0, sizeof(p3_global_settings));
 
   /* Arguments for primers ================================= */
+  a->p_args.repeat_lib = NULL;
+  a->o_args.repeat_lib = NULL;
+
   a->p_args.opt_size          = 20;
   a->p_args.min_size          = 18;
   a->p_args.max_size          = 27;

--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -1213,23 +1213,24 @@ cdef class _ThermoAnalysis:
         err_msg = ''
         try:
             global_settings_data = <p3_global_settings*> self.global_settings_data
-            if misprime_lib != None:
-                mp_lib = pdh_create_seq_lib(misprime_lib)
-                if mp_lib == NULL:
-                    err_msg = f'Issue creating misprime_lib {misprime_lib}'
-                    raise ValueError(
-                        f'Issue creating misprime_lib {misprime_lib}'
-                    )
 
-                global_settings_data[0].p_args.repeat_lib = mp_lib
+            if misprime_lib is None:
+                misprime_lib = {}
 
-            if mishyb_lib != None:
-                mh_lib = pdh_create_seq_lib(mishyb_lib)
-                if mh_lib == NULL:
-                    err_msg = f'Issue creating mishyb_lib: {mishyb_lib}'
-                    raise ValueError(err_msg)
-                global_settings_data[0].o_args.repeat_lib = mh_lib
+            mp_lib = pdh_create_seq_lib(misprime_lib)
+
+            global_settings_data[0].p_args.repeat_lib = mp_lib
+
+            if mishyb_lib is None:
+                mishyb_lib = {}
+
+            mh_lib = pdh_create_seq_lib(mishyb_lib)
+
+            global_settings_data[0].o_args.repeat_lib = mh_lib
+
         except (OSError, TypeError) as exc:
+            # Caught the exception, now raise a new one from the original
+            # post cleanup
             p3_destroy_global_settings(
                 <p3_global_settings*> self.global_settings_data
             )

--- a/tests/test_primerdesign.py
+++ b/tests/test_primerdesign.py
@@ -27,8 +27,8 @@ from __future__ import print_function
 import os
 import random
 import sys
+import time
 import unittest
-from time import sleep
 from typing import (
     Any,
     Dict,
@@ -431,7 +431,7 @@ class TestDesignBindings(unittest.TestCase):
                     ],
                 },
             )
-        sleep(0.1)  # Pause for any GC
+        time.sleep(0.1)  # Pause for any GC
         em = _get_mem_usage()
         print(
             f'\n\tMemory usage before {run_count} runs of design_primers: {sm}',
@@ -554,6 +554,29 @@ class TestDesignBindings(unittest.TestCase):
         self.assertEqual(result['PRIMER_INTERNAL_0'], [69, 24])
         self.assertEqual(result['PRIMER_INTERNAL'][0]['COORDS'], [69, 24])
         self.assertEqual(len(result['PRIMER_INTERNAL']), 5)
+
+        # Test timing of this function of empty dictionaries compared to None
+        t1 = time.time()
+        bindings.design_primers(
+            seq_args=seq_args,
+            global_args=global_args,
+            misprime_lib={},
+            mishyb_lib={},
+        )
+        dt1 = time.time() - t1
+
+        t2 = time.time()
+        bindings.design_primers(
+            seq_args=seq_args,
+            global_args=global_args,
+            misprime_lib=None,
+            mishyb_lib=None,
+        )
+        dt2 = time.time() - t2
+        # If the difference is less than 1 second, we are good
+        # Should be way less than 1 second but we are being conservative for
+        # the test in the cloud
+        assert abs(dt1 - dt2) < 1.0
 
     def test_PRIMER_SECONDARY_STRUCTURE_ALIGNMENT(self):
         '''Ensure all result pointers are initialized to NULL.


### PR DESCRIPTION
Fix `_ThermoAnalysis._set_globals_and_seq_args` for improper checks on `misprime_lib` and  `mishyb_lib` leading to incorrect initialization of `mp_lib` and `mh_lib` and extensive run delays.  See #133 

### Test code:
```python
import time

from primer3 import __version__
from primer3.bindings import design_primers

# FASTA file from https://www.ncbi.nlm.nih.gov/nuccore/NC_004547.2
ref_fasta = 'NC_004547.2.fa'

seq = '''\
GATTGATTGAAGTCCAGGCACCGATTCTCAGCCGTATCGGCGATGGCACACAGGATAACTTGTCTGGTAC
AGAAAAAGCGGTGCAGGTTAAGGTAAAAGCCTTACCGGATGCCACATTTGAAGTGGTGCACTCACTGGCA
AAATGGAAACGCAAAACGCTGGGCGCGTATGATTTTAGCTTCGGTGAAGGCATTTATACTCACATGAAGG
CGCTGCGTCCGGACGAAGATCGCCTGAGCCCGATCCACTCGGTTTATGTCGATCAGTGGGATTGGGAGCG
CGTGATGGAGGATGGCGAGCGCAATGCTGAATATCTGAAATCGACGGTCACGCGTATTTATCAAGGCATT
AAAGCGACTGAGGCTGCGGTACATCAGGCGTTTGGCATTCAGCCTTTCCTGCCAGAGCAGATTCATTTTG
TGCATACCGAAACCTTGCTGAAGCGTTATCCCGATCTGGACGCCAAAGGGCGTGAGCGAGCTATAGCTAA
AGAGCTGGGTGCGGTCTTCCTGATTGGGATTGGCGGTAAGCTGTCCAGCGGACACTCTCACGATGTGCGT
GCACCGGATTATGATGACTGGACGACACCAGGCGAGCAGGAATTGGCGGGTTTGAACGGCGATATCGTCG
TCTGGAACCCAGTCCTGAACGATGCGTTTGAGATTTCATCCATGGGTATCCGCGTGGACGCAGAGGCGCT
AACACGCCAACTGGCACTGACGCAGGATGAGGAACGTCTGAAGCTTGAATGGCATCAGGCGCTGCTGCGC
'''.replace('\n', '')

GLOBALS = {
    'PRIMER_OPT_SIZE': 20,
    'PRIMER_MIN_SIZE': 18,
    'PRIMER_MAX_SIZE': 25,
    'PRIMER_PRODUCT_SIZE_RANGE': [
        [200, 250], [250, 300],
        [150, 200], [100, 150],
        [70, 100],
    ],
    'PRIMER_NUM_RETURN': 50,
    'PRIMER_MISPRIMING_LIBRARY': ref_fasta,
    'PRIMER_LIB_AMBIGUITY_CODES_CONSENSUS': 0,
}

seq_args = {
    'SEQUENCE_ID': 'XXX',
    'SEQUENCE_TEMPLATE': seq,
}

print('Using empty dicts for misprime_lib and mishyb_lib')
start = time.time()
candidates = design_primers(
    seq_args,
    GLOBALS,
    misprime_lib={},
    mishyb_lib={},
)
taken = time.time() - start
print(
    f'primer3 {__version__} with empty dicts gave {len(candidates)} in '
    f'{round(taken, 2)} seconds'
)

print("\nUsing None for misprime_lib and mishyb_lib")
start = time.time()
candidates = design_primers(
    seq_args,
    GLOBALS,
    misprime_lib=None,
    mishyb_lib=None,
)

taken = time.time() - start
print(
    f'primer3 {__version__} with None gave {len(candidates)} in '
    f'{round(taken, 2)} seconds\n',
)
```

Before:
```text
Using empty dicts for misprime_lib and mishyb_lib
primer3 2.0.2 with empty dicts gave 1161 in 0.67 seconds

Using None for misprime_lib and mishyb_lib
primer3 2.0.2 with None gave 12 in 56.61 seconds
```

After
```text
Using empty dicts for misprime_lib and mishyb_lib
primer3 2.0.3 with empty dicts gave 1161 in 0.66 seconds

Using None for misprime_lib and mishyb_lib
primer3 2.0.3 with None gave 1161 in 0.66 seconds
```