### PR TITLE
2.0.3 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 2.0.3 (February 15, 2024)
+
+- Fix `_ThermoAnalysis._set_globals_and_seq_args` for improper checks on `misprime_lib` and
+`mishyb_lib` leading to incorrect initialization of `mp_lib` and `mh_lib`. See issue #133
+
 ## Version 2.0.2 (February 9, 2024)
 
 - Support for python 3.12 (build, test, docs)

--- a/CHANGES
+++ b/CHANGES
@@ -55,7 +55,9 @@
 - Migrated `primer3/wrappers.py` to `tests/wrappers.py` to indicate it should not be used.
 - Expanded test coverage and now using pytest for testing
 - Added `pre-commit` hooks
-- Call signature update and pattern update: `designPrimers` now `design_primers` integrates setting of sequence arguments and global arguments as they are coupled in `primer3_boulder_main.c`
+- Call signature update and pattern update: `designPrimers` now `design_primers` integrates setting of sequence arguments and global arguments as they are coupled in `primer3_boulder_main.c`.
+  Note `primer3.primerdesign` was removed, including `setGlobals`.
+  Replace `setGlobals(GLOBALS, MISPRIME, MISHYB)` and `designPrimers(SEQARGS)` with a single call `design_primers(SEQARGS, GLOBALS, MISPRIME, MISHYB)`.
 - `primer3` C code bug fixes to improve compiler warnings
 - Using `primer3` `read_boulder_record` to setup primer3 data structures instead of reproducing code in `primer3-py` C or Cython via a code signature update
 - `drawDimer` and `drawHairpin` updates to unify sequence structure output for testing

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -26,10 +26,10 @@ import os
 from typing import List
 
 # Per PEP-440 https://peps.python.org/pep-0440/#public-version-identifiers
-__version__ = '2.0.2'
+__version__ = '2.0.3'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
-    'Copyright 2014-2023, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'
+    'Copyright 2014-2024, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'
 )
 __license__ = 'GPLv2'
 DESCRIPTION = 'Python bindings for Primer3'

--- a/primer3/src/libprimer3/ABOUT.txt
+++ b/primer3/src/libprimer3/ABOUT.txt
@@ -1,4 +1,4 @@
-The source files in this directory are derived from the Primer 2.3.7
+The source files in this directory are derived from the Primer 2.6.1
 source and have been modified to make the library more amenable to
 Python bindings.
 

--- a/primer3/src/libprimer3/libprimer3flex.c
+++ b/primer3/src/libprimer3/libprimer3flex.c
@@ -300,6 +300,9 @@ pr_set_default_global_args_1(
   memset(a, 0, sizeof(p3_global_settings));
 
   /* Arguments for primers ================================= */
+  a->p_args.repeat_lib = NULL;
+  a->o_args.repeat_lib = NULL;
+
   a->p_args.opt_size          = 20;
   a->p_args.min_size          = 18;
   a->p_args.max_size          = 27;

--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -1213,23 +1213,24 @@ cdef class _ThermoAnalysis:
         err_msg = ''
         try:
             global_settings_data = <p3_global_settings*> self.global_settings_data
-            if misprime_lib != None:
-                mp_lib = pdh_create_seq_lib(misprime_lib)
-                if mp_lib == NULL:
-                    err_msg = f'Issue creating misprime_lib {misprime_lib}'
-                    raise ValueError(
-                        f'Issue creating misprime_lib {misprime_lib}'
-                    )
 
-                global_settings_data[0].p_args.repeat_lib = mp_lib
+            if misprime_lib is None:
+                misprime_lib = {}
 
-            if mishyb_lib != None:
-                mh_lib = pdh_create_seq_lib(mishyb_lib)
-                if mh_lib == NULL:
-                    err_msg = f'Issue creating mishyb_lib: {mishyb_lib}'
-                    raise ValueError(err_msg)
-                global_settings_data[0].o_args.repeat_lib = mh_lib
+            mp_lib = pdh_create_seq_lib(misprime_lib)
+
+            global_settings_data[0].p_args.repeat_lib = mp_lib
+
+            if mishyb_lib is None:
+                mishyb_lib = {}
+
+            mh_lib = pdh_create_seq_lib(mishyb_lib)
+
+            global_settings_data[0].o_args.repeat_lib = mh_lib
+
         except (OSError, TypeError) as exc:
+            # Caught the exception, now raise a new one from the original
+            # post cleanup
             p3_destroy_global_settings(
                 <p3_global_settings*> self.global_settings_data
             )

--- a/tests/test_primerdesign.py
+++ b/tests/test_primerdesign.py
@@ -27,8 +27,8 @@ from __future__ import print_function
 import os
 import random
 import sys
+import time
 import unittest
-from time import sleep
 from typing import (
     Any,
     Dict,
@@ -431,7 +431,7 @@ class TestDesignBindings(unittest.TestCase):
                     ],
                 },
             )
-        sleep(0.1)  # Pause for any GC
+        time.sleep(0.1)  # Pause for any GC
         em = _get_mem_usage()
         print(
             f'\n\tMemory usage before {run_count} runs of design_primers: {sm}',
@@ -554,6 +554,29 @@ class TestDesignBindings(unittest.TestCase):
         self.assertEqual(result['PRIMER_INTERNAL_0'], [69, 24])
         self.assertEqual(result['PRIMER_INTERNAL'][0]['COORDS'], [69, 24])
         self.assertEqual(len(result['PRIMER_INTERNAL']), 5)
+
+        # Test timing of this function of empty dictionaries compared to None
+        t1 = time.time()
+        bindings.design_primers(
+            seq_args=seq_args,
+            global_args=global_args,
+            misprime_lib={},
+            mishyb_lib={},
+        )
+        dt1 = time.time() - t1
+
+        t2 = time.time()
+        bindings.design_primers(
+            seq_args=seq_args,
+            global_args=global_args,
+            misprime_lib=None,
+            mishyb_lib=None,
+        )
+        dt2 = time.time() - t2
+        # If the difference is less than 1 second, we are good
+        # Should be way less than 1 second but we are being conservative for
+        # the test in the cloud
+        assert abs(dt1 - dt2) < 1.0
 
     def test_PRIMER_SECONDARY_STRUCTURE_ALIGNMENT(self):
         '''Ensure all result pointers are initialized to NULL.


### PR DESCRIPTION
- Clarify how to replace setGlobals as of v1.0.0 (#134)
- Fix _ThermoAnalysis._set_globals_and_seq_args for improper checks on misprime_lib and mishyb_lib (#135)