### PR TITLE
Add missing DEBUG flag guard around stderr message in thalflex

### DIFF
--- a/.github/workflows/primer3-py-ci-github-action.yml
+++ b/.github/workflows/primer3-py-ci-github-action.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pre-commit
+        pip install pytest pre-commit "setuptools>=67.1.0"
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest and then run pre-commit
       run: >

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,30 @@
 default_language_version:
-    python: python3.10
+    python: python3.12
 repos:
 -   repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.4.0
+    rev: v3.1.0
     hooks:
     -   id: add-trailing-comma
-        args: [--py36-plus]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: double-quote-string-fixer
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.0
     hooks:
     -   id: isort
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v2.0.1
+    rev: v2.0.4
     hooks:
     -   id: autopep8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.15.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-certifi]

--- a/primer3/src/libprimer3/thalflex.c
+++ b/primer3/src/libprimer3/thalflex.c
@@ -649,10 +649,12 @@ thal(
       }
 
     } else if((mode != THL_FAST) && (mode != THL_DEBUG_F) && (mode != THL_STRUCT)) {
+      #ifdef DEBUG
         if (print_output == 1) { /* primer3-py update to supress undesired printing */
           fputs("No secondary structure could be calculated\n", stderr);
         }
-        o->no_structure = 1;
+       #endif
+      o->no_structure = 1;
     }
 
     if(o->temp == -_INFINITY && (!strcmp(o->msg, ""))) { o->temp=0.0; }

--- a/tests/test_threadsafe.py
+++ b/tests/test_threadsafe.py
@@ -110,7 +110,7 @@ class TestThermoAnalysisInThread(unittest.TestCase):
         for t in thread_list:
             t.join()
 
-        print(f'total: {(time.time()-t0):0.2}')
+        print(f'total: {(time.time() - t0):0.2}')
 
         taf = thermoanalysis.ThermoAnalysis()
         t0 = time.time()
@@ -125,7 +125,7 @@ class TestThermoAnalysisInThread(unittest.TestCase):
             )
             self.assertEqual(new_res.tm, res.tm)
             self.assertEqual(new_res.dh, res.dh)
-        print(f'total: {(time.time()-t0):0.2}')
+        print(f'total: {(time.time() - t0):0.2}')
 
     def test_primer_design_thread_safety(self):
         '''Test primer design (`run_design`) for thread safety
@@ -207,7 +207,7 @@ class TestThermoAnalysisInThread(unittest.TestCase):
             )
             thread_list.append(t)
             t.start()
-        print(f'total: {(time.time()-t0):0.2}')
+        print(f'total: {(time.time() - t0):0.2}')
 
         taf = thermoanalysis.ThermoAnalysis()
         t0 = time.time()
@@ -220,4 +220,4 @@ class TestThermoAnalysisInThread(unittest.TestCase):
                 mishyb_lib=None,
             )
             self.assertEqual(new_res, res)
-        print(f'total: {(time.time()-t0):0.2}')
+        print(f'total: {(time.time() - t0):0.2}')


### PR DESCRIPTION
`primer3-py` does not rely on any of the original `stderr` print behavior of the `primer3` library -- any desirable text output is written to internal buffers rather than `stdout` or `stderr`. In cases where the text output was not needed for `primer3-py` functionality, it was disabled behind preprocessor directives (i.e., it could re-enabled for debug purposes with a respective flag). This PR fixes one outstanding instance of `stderr` printing that did not have this debug flag guard installed.

Addresses issue #146. Note that I also had to make some incidental changes to the `pre-commit` configuration (due to out of date dependencies, sunsetting of the inclusion of `setuptools` in `stdlib`, etc. That means this PR now supercedes  #143 