### PR TITLE
Python 3.13 Support

### DIFF
--- a/.github/workflows/build-wheels-pypi.yml
+++ b/.github/workflows/build-wheels-pypi.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-2022]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: checkout
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/setup-python@v4.4.0
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.13'
 
       - name: Install wheel
         run: python3 -m pip install wheel

--- a/.github/workflows/build-wheels-pypi.yml
+++ b/.github/workflows/build-wheels-pypi.yml
@@ -37,7 +37,7 @@ jobs:
       #     platforms: 'arm64'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: "==${{ matrix.python-version }}.*"
 
@@ -63,9 +63,9 @@ jobs:
           CIBW_TEST_COMMAND_LINUX: "pytest {project}/tests/test_thermoanalysis.py -v"
           CIBW_TEST_COMMAND_WINDOWS: "pytest {project}\\tests\\test_thermoanalysis.py"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-${{ matrix.python-version }}-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -80,14 +80,14 @@ jobs:
           python-version: '3.13'
 
       - name: Install wheel
-        run: python3 -m pip install wheel
+        run: python3 -m pip install wheel "setuptools>=67.1.0"
 
       - name: Build sdist
         run: python3 setup.py sdist --formats=gztar
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -96,14 +96,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: dist
+      - name: Download wheels & sdist
+        uses: actions/download-artifact@v4
 
       - name: Check files
-        run: ls -lR dist
+        run: ls -lR .
 
       - name: Upload to PyPI
         # upload to PyPI on every tag starting with 'v'

--- a/.github/workflows/build-wheels-pypi.yml
+++ b/.github/workflows/build-wheels-pypi.yml
@@ -98,9 +98,12 @@ jobs:
     steps:
       - name: Download wheels & sdist
         uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
 
       - name: Check files
-        run: ls -lR .
+        run: ls -lR dist/
 
       - name: Upload to PyPI
         # upload to PyPI on every tag starting with 'v'

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4.4.0
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install and run sphinx to build the docs
       run: |
         python -m pip install --upgrade pip

--- a/docs/miscellany.md
+++ b/docs/miscellany.md
@@ -44,7 +44,7 @@ doi: 10.1093/nar/gks596
 
 All project code, including the derivative Primer3 library, is licensed
 under GPLv2. The included Python and Python C API bindings are
-Copyright (c) 2014 Ben Pruitt, Nick Conway; Wyss Institute for
+Copyright (c) 2014-2025 Ben Pruitt, Nick Conway; 2014-2018 Wyss Institute for
 Biologically Inspired Engineering.
 
 See LICENSE for full GPLv2 license.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@
 
 ## Requirements
 
-**Primer3-py** is built and tested on MacOS, Linux and Windows 64-bit systems; we do not provide official Windows support. Python versions 3.8 - 3.12 builds are supported.
+**Primer3-py** is built and tested on MacOS, Linux and Windows 64-bit systems; we do not provide official Windows support. Python versions 3.8 - 3.13 builds are supported.
 
 Wheels are released for CPython versions following the [EOL model](https://devguide.python.org/versions/).
 

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2023. Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute
+# Copyright (C) 2014-2025. Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute
 # See LICENSE for full GPLv2 license.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -29,7 +29,7 @@ from typing import List
 __version__ = '2.0.3'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
-    'Copyright 2014-2024, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'
+    'Copyright 2014-2025, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'
 )
 __license__ = 'GPLv2'
 DESCRIPTION = 'Python bindings for Primer3'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ Installation
 ------------
 
 **Primer3-py** has no external runtime library dependencies and should compile
-on easily most Linux and MacOS systems that are running Python 3.8 - 3.11.
+on easily most Linux and MacOS systems that are running Python 3.8 - 3.13.
 Windows compilation is also generally easy.
 
 To build **Primer3-py** within the package directory run::
@@ -368,6 +368,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',
         'Topic :: Scientific/Engineering :: Bio-Informatics',

--- a/setup.py
+++ b/setup.py
@@ -369,7 +369,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Science/Research',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',


### PR DESCRIPTION
Adds support for Python 3.13 (as well as some incidental fixes for various GH actions deprecations).

Successful GH action pipeline run (wheel/sdist build): https://github.com/benpruitt/primer3-py/actions/runs/13359997780