### PR TITLE
2.1.0 release

### DIFF
--- a/.github/workflows/build-wheels-pypi.yml
+++ b/.github/workflows/build-wheels-pypi.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-2022]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: checkout
@@ -37,7 +37,7 @@ jobs:
       #     platforms: 'arm64'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: "==${{ matrix.python-version }}.*"
 
@@ -63,9 +63,9 @@ jobs:
           CIBW_TEST_COMMAND_LINUX: "pytest {project}/tests/test_thermoanalysis.py -v"
           CIBW_TEST_COMMAND_WINDOWS: "pytest {project}\\tests\\test_thermoanalysis.py"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-${{ matrix.python-version }}-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -77,17 +77,17 @@ jobs:
       - uses: actions/setup-python@v4.4.0
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.13'
 
       - name: Install wheel
-        run: python3 -m pip install wheel
+        run: python3 -m pip install wheel "setuptools>=67.1.0"
 
       - name: Build sdist
         run: python3 setup.py sdist --formats=gztar
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -96,14 +96,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
+      - name: Download wheels & sdist
+        uses: actions/download-artifact@v4
         with:
-          name: dist
           path: dist
+          merge-multiple: true
 
       - name: Check files
-        run: ls -lR dist
+        run: ls -lR dist/
 
       - name: Upload to PyPI
         # upload to PyPI on every tag starting with 'v'

--- a/.github/workflows/primer3-py-ci-github-action.yml
+++ b/.github/workflows/primer3-py-ci-github-action.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pre-commit
+        pip install pytest pre-commit "setuptools>=67.1.0"
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest and then run pre-commit
       run: >

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4.4.0
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install and run sphinx to build the docs
       run: |
         python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,30 @@
 default_language_version:
-    python: python3.10
+    python: python3.12
 repos:
 -   repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.4.0
+    rev: v3.1.0
     hooks:
     -   id: add-trailing-comma
-        args: [--py36-plus]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: double-quote-string-fixer
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.0
     hooks:
     -   id: isort
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v2.0.1
+    rev: v2.0.4
     hooks:
     -   id: autopep8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.15.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-certifi]

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 2.1.0 (February 17, 2025)
+
+- Support for python 3.13
+- Silence stderr output during ascii structure generation (issue #146)
+
 ## Version 2.0.3 (February 15, 2024)
 
 - Fix `_ThermoAnalysis._set_globals_and_seq_args` for improper checks on `misprime_lib` and

--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,10 @@
 # Changelog
 
-## Version 2.1.0 (February 17, 2025)
+## Version 2.1.0 (February 26, 2025)
 
 - Support for python 3.13
 - Silence stderr output during ascii structure generation (issue #146)
+- Updated default formamide concentration to match latest primer3web value + oligotm default (issue #140)
 
 ## Version 2.0.3 (February 15, 2024)
 

--- a/docs/miscellany.md
+++ b/docs/miscellany.md
@@ -44,7 +44,7 @@ doi: 10.1093/nar/gks596
 
 All project code, including the derivative Primer3 library, is licensed
 under GPLv2. The included Python and Python C API bindings are
-Copyright (c) 2014 Ben Pruitt, Nick Conway; Wyss Institute for
+Copyright (c) 2014-2025 Ben Pruitt, Nick Conway; 2014-2018 Wyss Institute for
 Biologically Inspired Engineering.
 
 See LICENSE for full GPLv2 license.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@
 
 ## Requirements
 
-**Primer3-py** is built and tested on MacOS, Linux and Windows 64-bit systems; we do not provide official Windows support. Python versions 3.8 - 3.12 builds are supported.
+**Primer3-py** is built and tested on MacOS, Linux and Windows 64-bit systems; we do not provide official Windows support. Python versions 3.8 - 3.13 builds are supported.
 
 Wheels are released for CPython versions following the [EOL model](https://devguide.python.org/versions/).
 

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -26,7 +26,7 @@ import os
 from typing import List
 
 # Per PEP-440 https://peps.python.org/pep-0440/#public-version-identifiers
-__version__ = '2.0.3'
+__version__ = '2.1.0'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
     'Copyright 2014-2025, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2023. Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute
+# Copyright (C) 2014-2025. Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute
 # See LICENSE for full GPLv2 license.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -29,7 +29,7 @@ from typing import List
 __version__ = '2.0.3'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
-    'Copyright 2014-2024, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'
+    'Copyright 2014-2025, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'
 )
 __license__ = 'GPLv2'
 DESCRIPTION = 'Python bindings for Primer3'

--- a/primer3/argdefaults.py
+++ b/primer3/argdefaults.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023. Ben Pruitt & Nick Conway
+# Copyright (C) 2023-2025. Ben Pruitt & Nick Conway
 # See LICENSE for full GPLv2 license.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -56,7 +56,7 @@ class Primer3PyArguments:
 
     dmso_conc: float = 0.0
     dmso_fact: float = 0.6
-    formamide_conc: float = 0.8
+    formamide_conc: float = 0.0
     annealing_temp_c: float = -10.0  # per `oligotm_main.c`` and `libprimer.c`
 
     def todict(self) -> dict:

--- a/primer3/src/libprimer3/thalflex.c
+++ b/primer3/src/libprimer3/thalflex.c
@@ -649,10 +649,12 @@ thal(
       }
 
     } else if((mode != THL_FAST) && (mode != THL_DEBUG_F) && (mode != THL_STRUCT)) {
+      #ifdef DEBUG
         if (print_output == 1) { /* primer3-py update to supress undesired printing */
           fputs("No secondary structure could be calculated\n", stderr);
         }
-        o->no_structure = 1;
+       #endif
+      o->no_structure = 1;
     }
 
     if(o->temp == -_INFINITY && (!strcmp(o->msg, ""))) { o->temp=0.0; }

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ Installation
 ------------
 
 **Primer3-py** has no external runtime library dependencies and should compile
-on easily most Linux and MacOS systems that are running Python 3.8 - 3.11.
+on easily most Linux and MacOS systems that are running Python 3.8 - 3.13.
 Windows compilation is also generally easy.
 
 To build **Primer3-py** within the package directory run::
@@ -368,7 +368,8 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
-        'Development Status :: 4 - Beta',
+        'Programming Language :: Python :: 3.13',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Science/Research',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',

--- a/tests/test_threadsafe.py
+++ b/tests/test_threadsafe.py
@@ -110,7 +110,7 @@ class TestThermoAnalysisInThread(unittest.TestCase):
         for t in thread_list:
             t.join()
 
-        print(f'total: {(time.time()-t0):0.2}')
+        print(f'total: {(time.time() - t0):0.2}')
 
         taf = thermoanalysis.ThermoAnalysis()
         t0 = time.time()
@@ -125,7 +125,7 @@ class TestThermoAnalysisInThread(unittest.TestCase):
             )
             self.assertEqual(new_res.tm, res.tm)
             self.assertEqual(new_res.dh, res.dh)
-        print(f'total: {(time.time()-t0):0.2}')
+        print(f'total: {(time.time() - t0):0.2}')
 
     def test_primer_design_thread_safety(self):
         '''Test primer design (`run_design`) for thread safety
@@ -207,7 +207,7 @@ class TestThermoAnalysisInThread(unittest.TestCase):
             )
             thread_list.append(t)
             t.start()
-        print(f'total: {(time.time()-t0):0.2}')
+        print(f'total: {(time.time() - t0):0.2}')
 
         taf = thermoanalysis.ThermoAnalysis()
         t0 = time.time()
@@ -220,4 +220,4 @@ class TestThermoAnalysisInThread(unittest.TestCase):
                 mishyb_lib=None,
             )
             self.assertEqual(new_res, res)
-        print(f'total: {(time.time()-t0):0.2}')
+        print(f'total: {(time.time() - t0):0.2}')


### PR DESCRIPTION
- Python 3.13 support (#148)
- Add missing DEBUG flag guard around stderr message in thalflex (#147, closes #146)
- Updated default formamide concentration to match latest primer3web value + oligotm default (closes #140)