### PR TITLE
Fix docs-building GH action

### DIFF
--- a/.github/workflows/primer3-py-ci-github-action.yml
+++ b/.github/workflows/primer3-py-ci-github-action.yml
@@ -1,6 +1,6 @@
 name: build, pytest and pre-commit
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-linux:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -6,6 +6,11 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+    branches:
+      - "**docs**"  # Matches any branch that contains "docs"
+
+  # Trigger on request (note this pushes to gh-pages and NOT gh-pages-test)
+  workflow_dispatch:
 
 jobs:
   docs:
@@ -24,9 +29,17 @@ jobs:
         cd docs/
         make html
         cd ..
-    - name: Commit documentation changes to the gh-pages branch
+    - name: Determine target branch
       run: |
-        git clone https://github.com/libnano/primer3-py.git --branch gh-pages --single-branch gh-pages
+        TAG_NAME=${GITHUB_REF#refs/tags/}
+        if [[ "$TAG_NAME" == v* || "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+          echo "BRANCH_NAME=gh-pages" >> $GITHUB_ENV
+        else
+          echo "BRANCH_NAME=gh-pages-test" >> $GITHUB_ENV
+        fi
+    - name: Commit documentation changes to the target branch
+      run: |
+        git clone https://github.com/libnano/primer3-py.git  --branch $BRANCH_NAME --single-branch gh-pages
         cp -r docs/_build/html/* gh-pages/
         cd gh-pages
         git config --local user.email "action@github.com"
@@ -35,10 +48,10 @@ jobs:
         git commit -m "Update documentation" -a || true
         # The above command will fail if no changes were present, so we ignore
         # the return code.
-    - name: Push changes to the gh-pages branch
+    - name: Push changes to the target branch
       uses: ad-m/github-push-action@master
       with:
-        branch: gh-pages
+        branch: ${{ env.BRANCH_NAME }}
         directory: gh-pages
         github_token: ${{ secrets.PRIMER3_TOKEN }}
         force: true

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3.3.0
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v4.4.0
       with:
         python-version: '3.12'
     - name: Install and run sphinx to build the docs
       run: |
         python -m pip install --upgrade pip
-        pip install cython myst-parser sphinx sphinx_rtd_theme sphinx-autodoc-typehints
+        pip install cython myst-parser sphinx sphinx_rtd_theme sphinx-autodoc-typehints setuptools
         python setup.py build_ext --inplace
         cd docs/
         make html


### PR DESCRIPTION
`setuptools` was removed from the standard Python distribution in a 3.12.x point release, which broke this workflow. It has now been added back in as an explicit installation step (this also implicitly includes the `distutils` variant that ships w/ `setuptools`. 

I also modified the GH action `yaml` to include affordances for triggering the workflow manually and on any branch that contains `docs`. In the event that the workflow is triggered based solely on the branch name, the results will be pushed to the `gh-pages-test` branch (rather than `gh-pages`). Triggers based on `vN.N.N` tags or manual triggers push to `gh-pages`.

I don't think this needs to be wrapped up in a release as it doesn't touch distribution code; this PR directly targets `master`.  