### PR TITLE
Pin `sphinx_rtd_theme` to 2.0.0

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install and run sphinx to build the docs
       run: |
         python -m pip install --upgrade pip
-        pip install cython myst-parser sphinx sphinx_rtd_theme sphinx-autodoc-typehints setuptools
+        pip install cython myst-parser sphinx sphinx_rtd_theme==2.0.0 sphinx-autodoc-typehints setuptools
         python setup.py build_ext --inplace
         cd docs/
         make html


### PR DESCRIPTION
Fixes an issue in which the version number was no longer displayed in the left hand column of the sphinx-generated docs (`gh-pages` docs)