### PR TITLE
2.2.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure version
+        shell: bash
         run: |
           # Get base version from validate job
           BASE_VERSION="${{ needs.validate-version.outputs.version }}"
@@ -130,6 +131,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure version
+        shell: bash
         run: |
           # Get base version from validate job
           BASE_VERSION="${{ needs.validate-version.outputs.version }}"
@@ -204,3 +206,4 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           verify_metadata: true
           verbose: true
+          skip_existing: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
           sed -i.bak "s/version=.*,/version='${VERSION}',/" setup.py
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: "==${{ matrix.python-version }}.*"
           CIBW_SKIP: "{*-musllinux_*,pp*}"  # Skip musl linux and PyPy versions
@@ -109,12 +109,12 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: "10.14"
           CIBW_BEFORE_BUILD: >-
             python -m pip install --upgrade pip &&
-            python -m pip install "Cython==3.0.12" pytest "setuptools>=67.1.0" wheel build &&
             cd {project} &&
-            python -m pip install -e .
+            python -m pip install -e ".[dev]"
           CIBW_TEST_COMMAND_MACOS: "pytest {project}/tests/test_thermoanalysis.py -v"
           CIBW_TEST_COMMAND_LINUX: "pytest {project}/tests/test_thermoanalysis.py -v"
           CIBW_TEST_COMMAND_WINDOWS: "pytest {project}\\tests\\test_thermoanalysis.py"
+          CIBW_BUILD_VERBOSITY: 1
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4
@@ -192,18 +192,18 @@ jobs:
 
       - name: Publish to PyPI
         if: inputs.is_test == false
-        uses: pypa/gh-action-pypi-publish@v1.8.11
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           password: ${{ secrets.PRIMER3_PYPI_API_TOKEN }}
-          verify_metadata: true
+          verify-metadata: true
           verbose: true
 
       - name: Publish to TestPyPI
         if: inputs.is_test == true
-        uses: pypa/gh-action-pypi-publish@v1.8.11
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           password: ${{ secrets.PRIMER3_TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
-          verify_metadata: true
+          verify-metadata: true
           verbose: true
-          skip_existing: false
+          skip-existing: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           # Extract version from __init__.py
           # This supports any valid PEP 440 version including pre-releases (e.g., 2.1.0a1)
-          VERSION=$(python -c "exec(open('primer3/__init__.py').read()); print(__version__)")
+          VERSION=$(sed -n "s/^__version__ = '\(.*\)'/\1/p" primer3/__init__.py)
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Base version from __init__.py: ${VERSION}"
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 2.2.0 (May 19, 2025)
+
+- Test improvements (determinism + increased coverage)
+- Sanitize `calc_tm` input (see issue #115)
+- Modernize build system & release process (see issue #154)
+
 ## Version 2.1.0 (February 26, 2025)
 
 - Support for python 3.13

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -26,7 +26,7 @@ import os
 from typing import List
 
 # Per PEP-440 https://peps.python.org/pep-0440/#public-version-identifiers
-__version__ = '2.1.0'
+__version__ = '2.2.0'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
     'Copyright 2014-2025, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'

--- a/tests/thermo_standard_values.json
+++ b/tests/thermo_standard_values.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
-    "generation_timestamp": "2025-05-19T09:05:52.910774",
-    "primer3_py_version": "2.1.0",
+    "generation_timestamp": "2025-05-19T18:52:05.599355",
+    "primer3_py_version": "2.2.0",
     "primer3_lib_version": "libprimer3 release 2.6.1",
     "python_version": "3.11.5 (main, Sep 11 2023, 08:31:25) [Clang 14.0.6 ]",
     "platform": {
@@ -13,13 +13,13 @@
     "dependencies": {
       "setuptools": "75.8.0",
       "wheel": "0.38.4",
-      "Cython": "not installed",
-      "pre-commit": "3.4.0",
+      "Cython": "3.1.1",
+      "pre-commit": "3.5.0",
       "pytest": "7.4.0",
       "tomli": "2.0.1"
     },
     "git_info": {
-      "branch": "feat/deterministic_tests",
+      "branch": "2.2.0-staging",
       "latest_tag": "v2.1.0"
     }
   },


### PR DESCRIPTION
- Test improvements (determinism + increased coverage) 
  - PR #158 
- Sanitize `calc_tm` input 
  - PR #156 
  - Closes issue #115
- Modernize build system & release process 
  - PR #155 
  - PR #157 
  - Closes issue #154

Note that this release bumps `Cython` support to the latest release (`3.1.0`) and pins the major version (the `Cython` dep was previously unpinned, which led to #154). 

**Pre-merge checklist:**
- [x] Version bump in `__init__.py`
- [x] Update `CHANGES`
- [x] Dry run release + docs workflows

**Dry run workflow instances:**
- [Release](https://github.com/libnano/primer3-py/actions/runs/15125374720)
- [Documentation](https://github.com/libnano/primer3-py/actions/runs/15124809403)