### PR TITLE
2.3.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-2022]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:
@@ -99,7 +99,7 @@ jobs:
           sed -i.bak "s/version=.*,/version='${VERSION}',/" setup.py
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: "==${{ matrix.python-version }}.*"
           CIBW_SKIP: "{*-musllinux_*,pp*}"  # Skip musl linux and PyPy versions
@@ -108,7 +108,7 @@ jobs:
           CIBW_ARCHS_WINDOWS: "auto64"
           MACOSX_DEPLOYMENT_TARGET: "10.14"
           CIBW_BEFORE_BUILD: >-
-            python -m pip install --upgrade pip &&
+            python -m pip install --upgrade pip setuptools wheel &&
             cd {project} &&
             python -m pip install -e ".[dev]"
           CIBW_TEST_COMMAND_MACOS: "pytest {project}/tests/test_thermoanalysis.py -v"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           ${{
             github.event_name == 'push'
             && fromJSON('["3.13"]')
-            || fromJSON('["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]')
+            || fromJSON('["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]')
           }}
       fail-fast: false
     defaults:

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 2.3.0 (Jan 6, 2026)
+
+- Support for Python 3.14
+- Support for objects that implement the __str__ interface (see issue #164)
+- Support for modern GCC (see issue #165)
+
 ## Version 2.2.0 (May 19, 2025)
 
 - Test improvements (determinism + increased coverage)

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -26,7 +26,7 @@ import os
 from typing import List
 
 # Per PEP-440 https://peps.python.org/pep-0440/#public-version-identifiers
-__version__ = '2.3.0rc1'
+__version__ = '2.3.0'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
     'Copyright 2014-2026, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'

--- a/primer3/__init__.py
+++ b/primer3/__init__.py
@@ -26,10 +26,10 @@ import os
 from typing import List
 
 # Per PEP-440 https://peps.python.org/pep-0440/#public-version-identifiers
-__version__ = '2.2.0'
+__version__ = '2.3.0rc1'
 __author__ = 'Ben Pruitt, Nick Conway'
 __copyright__ = (
-    'Copyright 2014-2025, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'
+    'Copyright 2014-2026, Ben Pruitt & Nick Conway; 2014-2018 Wyss Institute'
 )
 __license__ = 'GPLv2'
 DESCRIPTION = 'Python bindings for Primer3'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Bio-Informatics",

--- a/tests/test_str_rep_ifc_compat.py
+++ b/tests/test_str_rep_ifc_compat.py
@@ -1,8 +1,31 @@
+# Copyright (C) 2020-2026. Ben Pruitt & Nick Conway; Wyss Institute
+# See LICENSE for full GPLv2 license.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+'''
+tests.test_str_rep_ifc_compat
+~~~~~~~~~~~~~~~~~~~
+
+Unit tests covering support for objects that implement the __str__ interface.
+'''
+
 import primer3
 
 
 class SeqObj:
-    """Object with str representation."""
+    '''Object with str representation.'''
 
     def __init__(self, seq):
         self._seq = seq
@@ -12,7 +35,7 @@ class SeqObj:
 
 
 def test_calc_tm_with_object():
-    """Test strict analysis function (calc_tm) with a custom object."""
+    '''Test Tm calc support for __str__ objs'''
     obj = SeqObj('GTAAAACGACGGCCAGT')
     tm = primer3.calc_tm(obj)
 
@@ -20,7 +43,7 @@ def test_calc_tm_with_object():
 
 
 def test_calc_end_stability_with_object():
-    """analysis function (calc_end_stability) with custom objects."""
+    '''Test thermo analysis function support for __str__ objs'''
     obj = SeqObj('GTAAAACGACGGCCAGT')
 
     res = primer3.calc_end_stability(obj, obj)


### PR DESCRIPTION
- Support for Python 3.14
- Support for objects that implement the \_\_str\_\_ interface (see issue #164, PR #167)
- Support for modern GCC (see issue #165, PR #166)

Note: PRs #166 and #167 were already reviewed and merged to `master` (so are not included in this change set)