### PR TITLE
Fix misprime_lib/mishyb_lib rejecting bytes sequence values

### DIFF
--- a/primer3/thermoanalysis.pyx
+++ b/primer3/thermoanalysis.pyx
@@ -1495,7 +1495,7 @@ cdef inline seq_lib* pdh_create_seq_lib(object seq_dict) except NULL:
         if isinstance(seq_str, str):
             seq_b = seq_str.encode('utf8')
             seq_c = seq_b
-        elif isinstance(seq_name_str, bytes):
+        elif isinstance(seq_str, bytes):
             seq_c = seq_str
         else:
             destroy_seq_lib(sl)

--- a/tests/test_primerdesign.py
+++ b/tests/test_primerdesign.py
@@ -594,6 +594,21 @@ class TestDesignBindings(unittest.TestCase):
         # the test in the cloud
         assert abs(dt1 - dt2) < 1.0
 
+        # Library sequence values may be bytes as well as str; both must
+        # produce identical output. (pdh_create_seq_lib previously
+        # type-checked the dict key instead of the value, raising a spurious
+        # TypeError for bytes sequence values.)
+        libs_str = {'SEQ1': 'CACCATGGAGCTCCTGATATTAAAGGCGAATGCCATT'}
+        libs_bytes = {'SEQ1': b'CACCATGGAGCTCCTGATATTAAAGGCGAATGCCATT'}
+        self.assertEqual(
+            bindings.design_primers(
+                seq_args, global_args, misprime_lib=libs_bytes,
+            ),
+            bindings.design_primers(
+                seq_args, global_args, misprime_lib=libs_str,
+            ),
+        )
+
     def test_PRIMER_SECONDARY_STRUCTURE_ALIGNMENT(self):
         '''Ensure all result pointers are initialized to NULL.
         '''


### PR DESCRIPTION
Fixes #173

`pdh_create_seq_lib` type-checked the sequence *value* against the dict *key* (`seq_name_str`) instead of the value (`seq_str`), so a `str` key with a `bytes` value raised `TypeError` (surfaced as an empty `OSError`). This tests `seq_str` instead.

Added a regression test asserting `bytes` and `str` library values produce identical design output.